### PR TITLE
feat: improve mqtt resilience and surface status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,4 @@
 - Sensor data uses Highcharts solid gauges with Tailwind indicators; SkyCam image shares a two-column layout with the real-time graph.
 
 - Use `js/mqttClient.js` for all MQTT connections instead of direct library calls.
+- MQTT helper now emits `status` events (`connecting`, `connected`, `disconnected`, `reconnecting`, `error`) and uses exponential backoff reconnects up to 30s.

--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@
 </aside>
 <main class="flex-1 p-6 space-y-8">
   <h1 class="text-3xl font-bold text-gray-900">Dashboard</h1>
+  <div id="connectionStatus" class="flex items-center text-sm text-gray-700">
+    <span id="statusDot" class="h-2 w-2 rounded-full bg-yellow-500 mr-2"></span>
+    <span id="statusText">Connecting...</span>
+  </div>
 
   <!-- Sensor Data -->
   <section>
@@ -197,6 +201,46 @@ const topics = Object.keys(gaugeConfigs).concat([
   'Observatory/Scope/Computer','Observatory/Scope/Focus','Observatory/Scope/Dew','Observatory/Scope/Scope',
   'Observatory/Hue/PatioSensor','Observatory/Hue/ObservatorySensor','workshop/sensors/motion'
 ]);
+
+function setToggleDisabled(disabled) {
+  document.querySelectorAll('.toggleButton').forEach(button => {
+    button.disabled = disabled;
+    button.classList.toggle('opacity-50', disabled);
+    button.classList.toggle('cursor-not-allowed', disabled);
+  });
+}
+
+function updateConnectionStatus(status, info) {
+  const dot = document.getElementById('statusDot');
+  const text = document.getElementById('statusText');
+  let color = 'bg-red-500';
+  let message = 'Disconnected';
+  if (status === 'connected') {
+    color = 'bg-green-500';
+    message = 'Connected';
+    setToggleDisabled(false);
+  } else if (status === 'reconnecting') {
+    color = 'bg-yellow-500';
+    message = 'Reconnecting...';
+    setToggleDisabled(true);
+  } else if (status === 'connecting') {
+    color = 'bg-yellow-500';
+    message = 'Connecting...';
+    setToggleDisabled(true);
+  } else if (status === 'error') {
+    message = 'Error';
+    if (info && info.message) message += ': ' + info.message;
+    setToggleDisabled(true);
+  } else {
+    setToggleDisabled(true);
+  }
+  if (dot) dot.className = `h-2 w-2 rounded-full mr-2 ${color}`;
+  if (text) text.textContent = message;
+}
+
+mqttClient.on('status', updateConnectionStatus);
+mqttClient.on('error', err => console.error('MQTT client error:', err));
+setToggleDisabled(true);
 
 mqttClient.on('connect', function() {
   topics.forEach(t => { mqttClient.subscribe(t); toggleStates[t] = '0'; });

--- a/js/mqttClient.js
+++ b/js/mqttClient.js
@@ -1,36 +1,60 @@
 (function(global){
   function createClient({ brokerUrl, options = {} }) {
     const subscriptions = [];
-    const handlers = { message: [], connect: [], error: [] };
-    const client = mqtt.connect(brokerUrl, options);
+    const handlers = { message: [], connect: [], error: [], status: [] };
+    let client;
+    let reconnectDelay = 1000;
+    const maxDelay = options.maxReconnectDelay || 30000;
+    let ended = false;
 
-    const resubscribe = () => {
-      subscriptions.forEach(topic => client.subscribe(topic));
+    const connect = () => {
+      handlers.status.forEach(h => h('connecting'));
+      client = mqtt.connect(brokerUrl, { ...options, reconnectPeriod: 0 });
+
+      client.on('connect', () => {
+        reconnectDelay = 1000;
+        subscriptions.forEach(topic => client.subscribe(topic));
+        handlers.connect.forEach(h => h());
+        handlers.status.forEach(h => h('connected'));
+      });
+
+      client.on('message', (topic, message) => {
+        handlers.message.forEach(h => h(topic, message));
+      });
+
+      client.on('error', (err) => {
+        console.error('MQTT Error:', err);
+        handlers.error.forEach(h => h(err));
+        handlers.status.forEach(h => h('error', err));
+      });
+
+      client.on('close', handleDisconnect);
     };
 
-    client.on('connect', () => {
-      resubscribe();
-      handlers.connect.forEach(h => h());
-    });
+    const handleDisconnect = () => {
+      handlers.status.forEach(h => h('disconnected'));
+      if (ended) return;
+      const delay = reconnectDelay;
+      reconnectDelay = Math.min(maxDelay, reconnectDelay * 2);
+      handlers.status.forEach(h => h('reconnecting', delay));
+      setTimeout(connect, delay);
+    };
 
-    client.on('message', (topic, message) => {
-      handlers.message.forEach(h => h(topic, message));
-    });
-
-    client.on('error', (err) => {
-      handlers.error.forEach(h => h(err));
-    });
+    connect();
 
     return {
-      publish: (...args) => client.publish(...args),
+      publish: (...args) => client && client.publish(...args),
       subscribe: (topic) => {
         if (!subscriptions.includes(topic)) subscriptions.push(topic);
-        client.subscribe(topic);
+        if (client) client.subscribe(topic);
       },
       on: (event, handler) => {
         if (handlers[event]) handlers[event].push(handler);
       },
-      end: () => client.end()
+      end: () => {
+        ended = true;
+        if (client) client.end();
+      }
     };
   }
 


### PR DESCRIPTION
## Summary
- add exponential backoff reconnects and status events to shared MQTT client
- show connection status in dashboard and disable toggles when offline
- log MQTT errors for easier diagnostics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac45e90c98832eb500586c18f01c95