### PR TITLE
Derive MQTT topics from DOM attributes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,3 +12,4 @@
 
 - Use `js/mqttClient.js` for all MQTT connections instead of direct library calls.
 - MQTT helper now emits `status` events (`connecting`, `connected`, `disconnected`, `reconnecting`, `error`) and uses exponential backoff reconnects up to 30s.
+- MQTT topics should be derived from DOM elements with `data-topic`; flag topics without UI colour changes using `data-static`.

--- a/index.html
+++ b/index.html
@@ -35,12 +35,12 @@
   <section>
     <h2 class="text-xl font-semibold mb-4">Sensor Data</h2>
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-      <div id="gauge-clouds" class="h-48"></div>
-      <div id="gauge-rain" class="h-48"></div>
-      <div id="gauge-light" class="h-48"></div>
-      <div id="gauge-dew" class="h-48"></div>
-      <div id="gauge-sqm" class="h-48"></div>
-      <div id="gauge-stars" class="h-48"></div>
+      <div id="gauge-clouds" class="h-48" data-topic="Observatory/clouds" data-static></div>
+      <div id="gauge-rain" class="h-48" data-topic="Observatory/rain" data-static></div>
+      <div id="gauge-light" class="h-48" data-topic="Observatory/light" data-static></div>
+      <div id="gauge-dew" class="h-48" data-topic="Observatory/dewp" data-static></div>
+      <div id="gauge-sqm" class="h-48" data-topic="Observatory/sqm" data-static></div>
+      <div id="gauge-stars" class="h-48" data-topic="skycam/stars" data-static></div>
     </div>
   </section>
 
@@ -72,11 +72,11 @@
       </div>
       <div class="p-4 bg-white rounded shadow flex items-center">
         <span class="mr-2">Open Limit</span>
-        <span id="openLimitIndicator" class="h-3 w-3 rounded-full bg-gray-400"></span>
+        <span id="openLimitIndicator" class="h-3 w-3 rounded-full bg-gray-400" data-topic="Observatory/roof/openlimit"></span>
       </div>
       <div class="p-4 bg-white rounded shadow flex items-center">
         <span class="mr-2">Close Limit</span>
-        <span id="closeLimitIndicator" class="h-3 w-3 rounded-full bg-gray-400"></span>
+        <span id="closeLimitIndicator" class="h-3 w-3 rounded-full bg-gray-400" data-topic="Observatory/roof/closelimit"></span>
       </div>
     </div>
   </section>
@@ -195,12 +195,13 @@ const mqttClient = createClient({
 });
 
 const toggleStates = {};
-const topics = Object.keys(gaugeConfigs).concat([
-  'Observatory/roof/open','Observatory/roof/close','Observatory/roof/openlimit','Observatory/roof/closelimit',
-  'Observatory/roof/power','Observatory/lights/white','Observatory/lights/red','Observatory/lights/desk',
-  'Observatory/Scope/Computer','Observatory/Scope/Focus','Observatory/Scope/Dew','Observatory/Scope/Scope',
-  'Observatory/Hue/PatioSensor','Observatory/Hue/ObservatorySensor','workshop/sensors/motion'
-]);
+const topicElements = Array.from(document.querySelectorAll('[data-topic]'));
+const topics = Array.from(new Set(topicElements.map(el => el.getAttribute('data-topic'))));
+const staticTopics = new Set(
+  topicElements
+    .filter(el => el.hasAttribute('data-static'))
+    .map(el => el.getAttribute('data-topic'))
+);
 
 function setToggleDisabled(disabled) {
   document.querySelectorAll('.toggleButton').forEach(button => {
@@ -243,7 +244,10 @@ mqttClient.on('error', err => console.error('MQTT client error:', err));
 setToggleDisabled(true);
 
 mqttClient.on('connect', function() {
-  topics.forEach(t => { mqttClient.subscribe(t); toggleStates[t] = '0'; });
+  topics.forEach(t => {
+    mqttClient.subscribe(t);
+    if (!staticTopics.has(t)) toggleStates[t] = '0';
+  });
 });
 
 mqttClient.on('message', function(topic, message) {
@@ -254,8 +258,10 @@ mqttClient.on('message', function(topic, message) {
   }
   if (topic === 'Observatory/roof/openlimit') updateIndicator('openLimitIndicator', value);
   if (topic === 'Observatory/roof/closelimit') updateIndicator('closeLimitIndicator', value);
-  toggleStates[topic] = value;
-  updateToggleButton(topic, value);
+  if (!staticTopics.has(topic)) {
+    toggleStates[topic] = value;
+    updateToggleButton(topic, value);
+  }
 });
 
 document.querySelectorAll('.toggleButton').forEach(button => {


### PR DESCRIPTION
## Summary
- build MQTT topic list from DOM `data-topic` attributes and track `data-static` topics
- attach `data-topic` markers to gauges and roof limit indicators
- subscribe using generated lists and skip updates for static topics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac470ccca0832ea848a87975a4eae8