### PR TITLE
feat: externalize MQTT config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,4 +16,5 @@
 - SkyCam image and real-time graph sit in a bottom card section.
 - MQTT helper now emits `status` events (`connecting`, `connected`, `disconnected`, `reconnecting`, `error`) and uses exponential backoff reconnects up to 30s.
 - MQTT topics should be derived from DOM elements with `data-topic`; flag topics without UI colour changes using `data-static`.
+- MQTT connection settings are centralised in `js/mqttConfig.js`, which reads from environment variables or a `window.__ENV` object.
 

--- a/README.md
+++ b/README.md
@@ -9,3 +9,33 @@ Web interface for monitoring and controlling a small observatory and related har
 - **Roof and GPIO control** (`script.php`, `manualjob.php`): PHP endpoints that run system scripts to open/close the roof or toggle specific GPIO pins on the Raspberry Pi.
 
 The site depends on MQTT for live updates and on external Python scripts for hardware actions.
+
+## MQTT Configuration
+
+Connection details are centralised in `js/mqttConfig.js`, which reads values from environment variables or a `.env` file that is loaded at build time.
+
+Supported variables:
+
+```
+MQTT_BROKER_URL=ws://homeassistant.smeird.com
+MQTT_PORT=1884
+MQTT_USERNAME=your-user
+MQTT_PASSWORD=your-pass
+MQTT_GRAPH_TOPIC=Observatory/Graph/#
+MQTT_DASHBOARD_TOPICS=topic1,topic2
+```
+
+During deployment, expose these variables in the environment or inject them into the page via a global `window.__ENV` object before loading scripts:
+
+```
+<script>
+  window.__ENV = {
+    MQTT_BROKER_URL: 'wss://mqtt.example.com',
+    MQTT_PORT: '8083',
+    MQTT_USERNAME: 'user',
+    MQTT_PASSWORD: 'pass'
+  };
+</script>
+```
+
+Tools like [dotenv](https://github.com/motdotla/dotenv) can load the variables from a `.env` file during a build step.

--- a/index.html
+++ b/index.html
@@ -171,7 +171,9 @@
   </section>
 </main>
 
-<script>
+<script type="module">
+import { brokerUrl, port, username, password, dashboardTopics } from './js/mqttConfig.js';
+
 // Highcharts gauge setup
 function createGauge(id, title, min, max) {
   return Highcharts.chart(id, {
@@ -203,16 +205,19 @@ Object.entries(gaugeConfigs).forEach(([topic, cfg]) => {
 
 // MQTT handling
 const mqttClient = createClient({
-  brokerUrl: 'ws://homeassistant.smeird.com:1884',
+  brokerUrl: `${brokerUrl}:${port}`,
   options: {
-    username: 'smeird',
-    password: '92987974'
+    username,
+    password
   }
 });
 
 const toggleStates = {};
 const topicElements = Array.from(document.querySelectorAll('[data-topic]'));
-const topics = Array.from(new Set(topicElements.map(el => el.getAttribute('data-topic'))));
+const topics = Array.from(new Set([
+  ...topicElements.map(el => el.getAttribute('data-topic')),
+  ...dashboardTopics
+]));
 const staticTopics = new Set(
   topicElements
     .filter(el => el.hasAttribute('data-static'))

--- a/js/mqttConfig.js
+++ b/js/mqttConfig.js
@@ -1,0 +1,16 @@
+function getEnv(key, fallback = '') {
+  if (typeof window !== 'undefined' && window.__ENV && window.__ENV[key] !== undefined) {
+    return window.__ENV[key];
+  }
+  if (typeof process !== 'undefined' && process.env && process.env[key] !== undefined) {
+    return process.env[key];
+  }
+  return fallback;
+}
+
+export const brokerUrl = getEnv('MQTT_BROKER_URL', 'ws://homeassistant.smeird.com');
+export const port = parseInt(getEnv('MQTT_PORT', '1884'), 10);
+export const username = getEnv('MQTT_USERNAME', '');
+export const password = getEnv('MQTT_PASSWORD', '');
+export const dashboardTopics = getEnv('MQTT_DASHBOARD_TOPICS', '').split(',').filter(Boolean);
+export const graphTopic = getEnv('MQTT_GRAPH_TOPIC', 'Observatory/Graph/#');

--- a/realtimegraph.php
+++ b/realtimegraph.php
@@ -15,10 +15,11 @@
 </head>
 <body>
   <div id="containery" style="height: 800px;"></div>
-  <script type="text/javascript">
+  <script type="module">
+import { brokerUrl, port, graphTopic } from './js/mqttConfig.js';
 //settings BEGIN
-var MQTTbroker = 'wss://mqtt.smeird.com:8083';
-var MQTTsubTopic = 'Observatory/Graph/#'; //works with wildcard # and + topics dynamically now
+const MQTTbroker = `${brokerUrl}:${port}`;
+const MQTTsubTopic = graphTopic; //works with wildcard # and + topics dynamically now
 //settings END
 var chart; // global variable for chart
 var dataTopics = [];


### PR DESCRIPTION
## Summary
- centralize MQTT connection settings in js/mqttConfig.js
- load broker, port, creds, and topics from environment variables
- document environment-based MQTT configuration

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ac48d75df8832ea100137e8b589007