### PR TITLE
feat: use sqlite-backed configuration with web editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,5 +17,6 @@
 - SkyCam image sits in a bottom card section.
 - MQTT helper now emits `status` events (`connecting`, `connected`, `disconnected`, `reconnecting`, `error`) and uses exponential backoff reconnects up to 30s.
 - MQTT topics should be derived from DOM elements with `data-topic`; flag topics without UI colour changes using `data-static`.
-- MQTT connection settings are centralised in `js/mqttConfig.js`, which reads from environment variables or a `window.__ENV` object.
+- MQTT connection settings now load from a SQLite `config.db` via `js/mqttConfig.js` fetching `/get_config.php`.
+- A `settings.html` page allows editing these values and persists them through `/save_config.php`.
 

--- a/config.php
+++ b/config.php
@@ -1,0 +1,33 @@
+<?php
+function getDb() {
+    $db = new SQLite3(__DIR__ . '/config.db');
+    $db->exec('CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT)');
+    return $db;
+}
+
+function getAllSettings() {
+    $db = getDb();
+    $res = $db->query('SELECT key, value FROM settings');
+    $settings = [];
+    while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+        $settings[$row['key']] = $row['value'];
+    }
+    return $settings;
+}
+
+function getSetting($key, $default = '') {
+    $db = getDb();
+    $stmt = $db->prepare('SELECT value FROM settings WHERE key = :key');
+    $stmt->bindValue(':key', $key, SQLITE3_TEXT);
+    $result = $stmt->execute()->fetchArray(SQLITE3_ASSOC);
+    return $result ? $result['value'] : $default;
+}
+
+function setSetting($key, $value) {
+    $db = getDb();
+    $stmt = $db->prepare('REPLACE INTO settings (key, value) VALUES (:key, :value)');
+    $stmt->bindValue(':key', $key, SQLITE3_TEXT);
+    $stmt->bindValue(':value', $value, SQLITE3_TEXT);
+    $stmt->execute();
+}
+?>

--- a/get_config.php
+++ b/get_config.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+$defaults = [
+    'MQTT_BROKER_URL' => 'ws://homeassistant.smeird.com',
+    'MQTT_PORT' => '1884',
+    'MQTT_USERNAME' => '',
+    'MQTT_PASSWORD' => '',
+    'MQTT_DASHBOARD_TOPICS' => ''
+];
+
+$stored = getAllSettings();
+
+$config = [];
+foreach ($defaults as $key => $value) {
+    $config[$key] = $stored[$key] ?? $value;
+}
+
+header('Content-Type: application/json');
+echo json_encode([
+    'brokerUrl' => $config['MQTT_BROKER_URL'],
+    'port' => (int)$config['MQTT_PORT'],
+    'username' => $config['MQTT_USERNAME'],
+    'password' => $config['MQTT_PASSWORD'],
+    'dashboardTopics' => array_values(array_filter(explode(',', $config['MQTT_DASHBOARD_TOPICS'])))
+]);
+?>

--- a/index.html
+++ b/index.html
@@ -159,7 +159,9 @@
 </main>
 
 <script type="module">
-import { brokerUrl, port, username, password, dashboardTopics } from './js/mqttConfig.js';
+import { loadConfig } from './js/mqttConfig.js';
+
+const { brokerUrl, port, username, password, dashboardTopics } = await loadConfig();
 
 // Highcharts gauge setup
 function createGauge(id, title, min, max) {

--- a/js/mqttConfig.js
+++ b/js/mqttConfig.js
@@ -1,16 +1,14 @@
-function getEnv(key, fallback = '') {
-  if (typeof window !== 'undefined' && window.__ENV && window.__ENV[key] !== undefined) {
-    return window.__ENV[key];
+export async function loadConfig() {
+  const res = await fetch('./get_config.php');
+  if (!res.ok) {
+    throw new Error('Failed to load config');
   }
-  if (typeof process !== 'undefined' && process.env && process.env[key] !== undefined) {
-    return process.env[key];
-  }
-  return fallback;
+  const data = await res.json();
+  return {
+    brokerUrl: data.brokerUrl,
+    port: parseInt(data.port, 10),
+    username: data.username,
+    password: data.password,
+    dashboardTopics: data.dashboardTopics
+  };
 }
-
-export const brokerUrl = getEnv('MQTT_BROKER_URL', 'ws://homeassistant.smeird.com');
-export const port = parseInt(getEnv('MQTT_PORT', '1884'), 10);
-export const username = getEnv('MQTT_USERNAME', '');
-export const password = getEnv('MQTT_PASSWORD', '');
-export const dashboardTopics = getEnv('MQTT_DASHBOARD_TOPICS', '').split(',').filter(Boolean);
-

--- a/save_config.php
+++ b/save_config.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/config.php';
+
+$allowed = [
+    'MQTT_BROKER_URL',
+    'MQTT_PORT',
+    'MQTT_USERNAME',
+    'MQTT_PASSWORD',
+    'MQTT_DASHBOARD_TOPICS'
+];
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!is_array($input)) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid input']);
+    exit;
+}
+
+foreach ($allowed as $key) {
+    if (isset($input[$key])) {
+        setSetting($key, $input[$key]);
+    }
+}
+
+echo json_encode(['status' => 'ok']);
+?>

--- a/settings.html
+++ b/settings.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Settings</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 min-h-screen flex items-center justify-center">
+  <div class="bg-white p-6 rounded shadow w-full max-w-md">
+    <h1 class="text-xl mb-4">Configuration</h1>
+    <form id="settingsForm" class="space-y-4">
+      <div>
+        <label class="block text-sm font-medium">MQTT Broker URL</label>
+        <input name="MQTT_BROKER_URL" class="mt-1 p-2 border w-full" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium">MQTT Port</label>
+        <input name="MQTT_PORT" type="number" class="mt-1 p-2 border w-full" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium">MQTT Username</label>
+        <input name="MQTT_USERNAME" class="mt-1 p-2 border w-full" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium">MQTT Password</label>
+        <input name="MQTT_PASSWORD" type="password" class="mt-1 p-2 border w-full" />
+      </div>
+      <div>
+        <label class="block text-sm font-medium">Dashboard Topics (comma-separated)</label>
+        <input name="MQTT_DASHBOARD_TOPICS" class="mt-1 p-2 border w-full" />
+      </div>
+      <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save</button>
+    </form>
+    <div id="status" class="mt-4 text-sm"></div>
+  </div>
+  <script type="module">
+    async function loadSettings() {
+      const res = await fetch('./get_config.php');
+      const cfg = await res.json();
+      const map = {
+        MQTT_BROKER_URL: cfg.brokerUrl,
+        MQTT_PORT: cfg.port,
+        MQTT_USERNAME: cfg.username,
+        MQTT_PASSWORD: cfg.password,
+        MQTT_DASHBOARD_TOPICS: cfg.dashboardTopics.join(',')
+      };
+      Object.entries(map).forEach(([k,v]) => {
+        document.querySelector(`[name="${k}"]`).value = v;
+      });
+    }
+    loadSettings();
+
+    document.getElementById('settingsForm').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const data = Object.fromEntries(new FormData(e.target).entries());
+      const res = await fetch('./save_config.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      document.getElementById('status').textContent = res.ok ? 'Saved' : 'Error';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- load MQTT settings from SQLite instead of environment variables
- add PHP endpoints and settings page to view/edit configuration
- document new SQLite-based config approach

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4d703f78832ea701d75aae848e9f