### PR TITLE
Expose settings page and fix config fetch paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,4 +19,5 @@
 - MQTT topics should be derived from DOM elements with `data-topic`; flag topics without UI colour changes using `data-static`.
 - MQTT connection settings now load from a SQLite `config.db` via `js/mqttConfig.js` fetching `/get_config.php`.
 - A `settings.html` page allows editing these values and persists them through `/save_config.php`.
+- Client-side config fetches should use absolute paths (e.g. `/get_config.php`) to ensure correct resolution from nested directories.
 

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
       <li><a class="block px-2 py-1 hover:bg-gray-700" href="http://ob.smeird.com" target="_blank">Public obs</a></li>
       <li><a class="block px-2 py-1 hover:bg-gray-700" href="http://www.smeird.com" target="_blank">Public Weather</a></li>
       <li><a class="block px-2 py-1 hover:bg-gray-700" href="https://clearoutside.com/forecast/51.81/-0.29" target="_blank">Night Forecast</a></li>
+      <li><a class="block px-2 py-1 hover:bg-gray-700" href="settings.html">Settings</a></li>
     </ul>
   </nav>
 </aside>

--- a/js/mqttConfig.js
+++ b/js/mqttConfig.js
@@ -1,5 +1,5 @@
 export async function loadConfig() {
-  const res = await fetch('./get_config.php');
+  const res = await fetch('/get_config.php');
   if (!res.ok) {
     throw new Error('Failed to load config');
   }

--- a/settings.html
+++ b/settings.html
@@ -35,7 +35,7 @@
   </div>
   <script type="module">
     async function loadSettings() {
-      const res = await fetch('./get_config.php');
+      const res = await fetch('/get_config.php');
       const cfg = await res.json();
       const map = {
         MQTT_BROKER_URL: cfg.brokerUrl,
@@ -53,7 +53,7 @@
     document.getElementById('settingsForm').addEventListener('submit', async (e) => {
       e.preventDefault();
       const data = Object.fromEntries(new FormData(e.target).entries());
-      const res = await fetch('./save_config.php', {
+      const res = await fetch('/save_config.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data)


### PR DESCRIPTION
## Summary
- Add settings page link to sidebar navigation
- Fetch MQTT configuration using absolute paths for reliability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4ff8080c832e849058dfa143bdc9