### PR TITLE
Ensure settings save returns JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,5 @@
 - A `settings.html` page allows editing these values and persists them through `/save_config.php`.
 - Client-side config fetches should use absolute paths (e.g. `/get_config.php`) to ensure correct resolution from nested directories.
 
+- Configuration endpoints respond with JSON and proper `Content-Type` headers; client pages should surface server error messages.
+

--- a/save_config.php
+++ b/save_config.php
@@ -1,6 +1,9 @@
 <?php
 require_once __DIR__ . '/config.php';
 
+// Always return JSON so the client can parse the response reliably
+header('Content-Type: application/json');
+
 $allowed = [
     'MQTT_BROKER_URL',
     'MQTT_PORT',

--- a/settings.html
+++ b/settings.html
@@ -53,12 +53,17 @@
     document.getElementById('settingsForm').addEventListener('submit', async (e) => {
       e.preventDefault();
       const data = Object.fromEntries(new FormData(e.target).entries());
-      const res = await fetch('/save_config.php', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data)
-      });
-      document.getElementById('status').textContent = res.ok ? 'Saved' : 'Error';
+      try {
+        const res = await fetch('/save_config.php', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data)
+        });
+        const body = await res.json();
+        document.getElementById('status').textContent = res.ok ? 'Saved' : (body.error || 'Error');
+      } catch {
+        document.getElementById('status').textContent = 'Error';
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Return JSON with appropriate content-type from `save_config.php`
- Parse save responses in `settings.html` and show server errors
- Document JSON response convention in `AGENTS.md`

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac53cdea60832ea9ca5660ed0b53ec