### PR TITLE
Add SQLite-backed config and dynamic control panel

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,7 +1,11 @@
 <?php
 function getDb() {
     $db = new SQLite3(__DIR__ . '/config.db');
+    // create tables for simple key/value settings as well as dynamic lists
     $db->exec('CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT)');
+    $db->exec('CREATE TABLE IF NOT EXISTS sensors (id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT UNIQUE, unit TEXT, name TEXT)');
+    $db->exec('CREATE TABLE IF NOT EXISTS switches (id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT UNIQUE, name TEXT)');
+    $db->exec('CREATE TABLE IF NOT EXISTS roof (id INTEGER PRIMARY KEY CHECK (id = 1), open_path TEXT, open_limit TEXT, close_path TEXT, close_limit TEXT)');
     return $db;
 }
 
@@ -28,6 +32,71 @@ function setSetting($key, $value) {
     $stmt = $db->prepare('REPLACE INTO settings (key, value) VALUES (:key, :value)');
     $stmt->bindValue(':key', $key, SQLITE3_TEXT);
     $stmt->bindValue(':value', $value, SQLITE3_TEXT);
+    $stmt->execute();
+}
+
+function getSensors() {
+    $db = getDb();
+    $res = $db->query('SELECT path, unit, name FROM sensors ORDER BY id');
+    $sensors = [];
+    while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+        $sensors[] = $row;
+    }
+    return $sensors;
+}
+
+function replaceSensors($sensors) {
+    $db = getDb();
+    $db->exec('DELETE FROM sensors');
+    $stmt = $db->prepare('INSERT INTO sensors (path, unit, name) VALUES (:path, :unit, :name)');
+    foreach ($sensors as $sensor) {
+        if (!isset($sensor['path'])) continue;
+        $stmt->bindValue(':path', $sensor['path'], SQLITE3_TEXT);
+        $stmt->bindValue(':unit', $sensor['unit'] ?? '', SQLITE3_TEXT);
+        $stmt->bindValue(':name', $sensor['name'] ?? '', SQLITE3_TEXT);
+        $stmt->execute();
+    }
+}
+
+function getSwitches() {
+    $db = getDb();
+    $res = $db->query('SELECT path, name FROM switches ORDER BY id');
+    $switches = [];
+    while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
+        $switches[] = $row;
+    }
+    return $switches;
+}
+
+function replaceSwitches($switches) {
+    $db = getDb();
+    $db->exec('DELETE FROM switches');
+    $stmt = $db->prepare('INSERT INTO switches (path, name) VALUES (:path, :name)');
+    foreach ($switches as $sw) {
+        if (!isset($sw['path'])) continue;
+        $stmt->bindValue(':path', $sw['path'], SQLITE3_TEXT);
+        $stmt->bindValue(':name', $sw['name'] ?? '', SQLITE3_TEXT);
+        $stmt->execute();
+    }
+}
+
+function getRoof() {
+    $db = getDb();
+    $res = $db->query('SELECT open_path, open_limit, close_path, close_limit FROM roof WHERE id = 1');
+    $row = $res->fetchArray(SQLITE3_ASSOC);
+    if (!$row) {
+        $row = ['open_path' => '', 'open_limit' => '', 'close_path' => '', 'close_limit' => ''];
+    }
+    return $row;
+}
+
+function setRoof($data) {
+    $db = getDb();
+    $stmt = $db->prepare('REPLACE INTO roof (id, open_path, open_limit, close_path, close_limit) VALUES (1, :open_path, :open_limit, :close_path, :close_limit)');
+    $stmt->bindValue(':open_path', $data['open_path'] ?? '', SQLITE3_TEXT);
+    $stmt->bindValue(':open_limit', $data['open_limit'] ?? '', SQLITE3_TEXT);
+    $stmt->bindValue(':close_path', $data['close_path'] ?? '', SQLITE3_TEXT);
+    $stmt->bindValue(':close_limit', $data['close_limit'] ?? '', SQLITE3_TEXT);
     $stmt->execute();
 }
 ?>

--- a/get_config.php
+++ b/get_config.php
@@ -10,11 +10,12 @@ $defaults = [
 ];
 
 $stored = getAllSettings();
-
 $config = [];
 foreach ($defaults as $key => $value) {
     $config[$key] = $stored[$key] ?? $value;
 }
+
+$roof = getRoof();
 
 header('Content-Type: application/json');
 echo json_encode([
@@ -22,6 +23,12 @@ echo json_encode([
     'port' => (int)$config['MQTT_PORT'],
     'username' => $config['MQTT_USERNAME'],
     'password' => $config['MQTT_PASSWORD'],
-    'dashboardTopics' => array_values(array_filter(explode(',', $config['MQTT_DASHBOARD_TOPICS'])))
+    'dashboardTopics' => array_values(array_filter(explode(',', $config['MQTT_DASHBOARD_TOPICS']))),
+    'sensors' => getSensors(),
+    'switches' => getSwitches(),
+    'roof' => [
+        'open' => ['path' => $roof['open_path'], 'limit' => $roof['open_limit']],
+        'close' => ['path' => $roof['close_path'], 'limit' => $roof['close_limit']]
+    ]
 ]);
 ?>

--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
 <script src="https://unpkg.com/mqtt/dist/mqtt.min.js"></script>
 <script src="js/mqttClient.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
-<script src="https://code.highcharts.com/highcharts-more.js"></script>
-<script src="https://code.highcharts.com/modules/solid-gauge.js"></script>
 <script src="https://code.highcharts.com/modules/bullet.js"></script>
 </head>
 <body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 flex">
@@ -34,145 +32,47 @@
     <span id="statusText">Connecting...</span>
   </div>
 
-  <!-- Sensor Data -->
+  <!-- Sensors -->
   <section class="bg-white rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4">Sensor Data</h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-
-      <div id="gauge-clouds" class="h-48" data-topic="Observatory/clouds" data-static></div>
-      <div id="gauge-rain" class="h-48" data-topic="Observatory/rain" data-static></div>
-      <div id="gauge-light" class="h-48" data-topic="Observatory/light" data-static></div>
-      <div id="gauge-dew" class="h-48" data-topic="Observatory/dewp" data-static></div>
-      <div id="gauge-sqm" class="h-48" data-topic="Observatory/sqm" data-static></div>
-      <div id="gauge-stars" class="h-48" data-topic="skycam/stars" data-static></div>
-    </div>
+    <h2 class="text-xl font-semibold mb-4">Sensors</h2>
+    <div id="sensorsContainer" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"></div>
   </section>
 
-  <!-- SkyCam -->
-  <section class="bg-white rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4">SkyCam</h2>
-    <a href="http://skycam.smeird.com" class="block">
-      <img id="liveImage" src="https://skycam.smeird.com/indi-allsky/images/latest.jpg?cacheBuster=123456" alt="SkyCam Image" class="w-full h-auto rounded">
-    </a>
-  </section>
-
-  <!-- Roof Controls -->
+  <!-- Roof -->
   <section class="bg-white rounded shadow p-6">
     <h2 class="text-xl font-semibold mb-4">Roof Controls</h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>Open Roof</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/roof/open">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>Close Roof</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/roof/close">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center">
-        <span class="mr-2">Open Limit</span>
-        <span id="openLimitIndicator" class="h-3 w-3 rounded-full bg-gray-400" data-topic="Observatory/roof/openlimit"></span>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center">
-        <span class="mr-2">Close Limit</span>
-        <span id="closeLimitIndicator" class="h-3 w-3 rounded-full bg-gray-400" data-topic="Observatory/roof/closelimit"></span>
-      </div>
-    </div>
+    <div id="roofControls" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"></div>
   </section>
 
-  <!-- Observatory Switches -->
+  <!-- Switches -->
   <section class="bg-white rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4">Observatory Switches</h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>12V Power</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/roof/power">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>White Lights</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/lights/white">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>Red Lights</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/lights/red">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>Desk Lights</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/lights/desk">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>PC</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/Scope/Computer">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>Focus</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/Scope/Focus">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>Dew</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/Scope/Dew">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>Scope</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/Scope/Scope">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>Patio Sensor</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/Hue/PatioSensor">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>Veg Sensor</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="Observatory/Hue/ObservatorySensor">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-      <div class="p-4 bg-white rounded shadow flex items-center justify-between">
-        <span>Workshop Motion</span>
-        <button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="workshop/sensors/motion">
-          <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-        </button>
-      </div>
-    </div>
+    <h2 class="text-xl font-semibold mb-4">Switches</h2>
+    <div id="switchesContainer" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"></div>
   </section>
 
-
+  <!-- Graphs -->
+  <section class="bg-white rounded shadow p-6">
+    <h2 class="text-xl font-semibold mb-4">Graphs</h2>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div id="bullet-clouds" class="h-32"></div>
+      <div id="bullet-light" class="h-32"></div>
+      <div id="bullet-rain" class="h-32"></div>
+      <div id="bullet-hum" class="h-32"></div>
+      <div id="bullet-sqm" class="h-32"></div>
+    </div>
+  </section>
 </main>
 
 <script type="module">
 import { loadConfig } from './js/mqttConfig.js';
 
-let brokerUrl, port, username, password;
-let dashboardTopics = [];
+let brokerUrl, port, username, password, dashboardTopics, sensors, switches, roof;
 let mqttClient;
 try {
-  ({ brokerUrl, port, username, password, dashboardTopics } = await loadConfig());
+  ({ brokerUrl, port, username, password, dashboardTopics, sensors, switches, roof } = await loadConfig());
   mqttClient = createClient({
     brokerUrl: `${brokerUrl}:${port}`,
-    options: {
-      username,
-      password
-    }
+    options: { username, password }
   });
 } catch (err) {
   const statusEl = document.getElementById('statusText');
@@ -181,79 +81,89 @@ try {
   console.error('MQTT init error:', err);
 }
 
-// Highcharts gauge setup
-function createGauge(id, title, min, max) {
-  return Highcharts.chart(id, {
-    chart: { type: 'solidgauge' },
-    title: { text: title },
-    pane: { center: ['50%', '85%'], size: '140%', startAngle: -90, endAngle: 90,
-      background: { innerRadius: '60%', outerRadius: '100%', shape: 'arc' } },
-    yAxis: { min: min, max: max, lineWidth: 0, tickAmount: 2,
-      labels: { y: 16 }, stops: [[0.1, '#f87171'], [0.5, '#fbbf24'], [0.9, '#34d399']] },
-    series: [{ data: [0], dataLabels: { format: '<span class="text-xl">{y}</span>' } }],
-    tooltip: { enabled: false },
-    credits: { enabled: false }
-  });
-}
-
-function createBullet(id, title, min, max, target, color, neg) {
-  return Highcharts.chart(id, {
-    chart: { type: 'bullet', inverted: true },
-    title: { text: title, align: 'left' },
-    xAxis: { categories: [''], title: null },
-    yAxis: { min: min, max: max, title: null, plotBands: [] },
-    series: [{
-      data: [{ y: 0, target: target }],
-      threshold: target,
-      color: color,
-      negativeColor: neg
-    }],
-    tooltip: { enabled: false },
-    credits: { enabled: false }
-  });
-}
-
-const gaugeConfigs = {
-  'Observatory/clouds': { id: 'gauge-clouds', title: 'Clouds', min: -40, max: 40 },
-  'Observatory/rain': { id: 'gauge-rain', title: 'Rain', min: 0, max: 10000 },
-  'Observatory/light': { id: 'gauge-light', title: 'Light', min: 0, max: 20000 },
-  'Observatory/dewp': { id: 'gauge-dew', title: 'Dew', min: -10, max: 30 },
-  'Observatory/sqm': { id: 'gauge-sqm', title: 'SQM', min: 0, max: 22 },
-  'skycam/stars': { id: 'gauge-stars', title: 'Stars', min: 0, max: 50 }
-};
-
-const gaugeCharts = {};
-Object.entries(gaugeConfigs).forEach(([topic, cfg]) => {
-  gaugeCharts[topic] = createGauge(cfg.id, cfg.title, cfg.min, cfg.max);
-});
-
-const bulletConfigs = {
-  'Observatory/Graph/clouds': { id: 'bullet-clouds', title: 'Clouds', min: -40, max: 40, target: -12, color: 'red', neg: 'green' },
-  'Observatory/Graph/light': { id: 'bullet-light', title: 'Light', min: 0, max: 20000, target: 10000, color: 'green', neg: 'red' },
-  'Observatory/Graph/rain': { id: 'bullet-rain', title: 'Rain', min: 0, max: 10000, target: 4200, color: 'green', neg: 'red' },
-  'Observatory/Graph/hum': { id: 'bullet-hum', title: 'Humidity', min: 0, max: 100, target: 95, color: 'red', neg: 'green' },
-  'Observatory/Graph/sqm': { id: 'bullet-sqm', title: 'Darkness', min: 0, max: 22, target: 15, color: 'green', neg: 'red' }
-};
-
-const bulletCharts = {};
-Object.entries(bulletConfigs).forEach(([topic, cfg]) => {
-  bulletCharts[topic] = createBullet(cfg.id, cfg.title, cfg.min, cfg.max, cfg.target, cfg.color, cfg.neg);
-});
-
-// MQTT handling
+const sensorValueEls = {};
+const indicatorEls = {};
+const topics = new Set(dashboardTopics);
 const toggleStates = {};
 
-const topicElements = Array.from(document.querySelectorAll('[data-topic]'));
-const topics = Array.from(new Set([
-  ...topicElements.map(el => el.getAttribute('data-topic')),
-  ...dashboardTopics
-]));
-const staticTopics = new Set(
-  topicElements
-    .filter(el => el.hasAttribute('data-static'))
-    .map(el => el.getAttribute('data-topic'))
-);
+function addSensorCards() {
+  const container = document.getElementById('sensorsContainer');
+  sensors.forEach(s => {
+    const card = document.createElement('div');
+    card.className = 'p-4 bg-white rounded shadow flex items-center justify-between';
+    const valueEl = document.createElement('span');
+    valueEl.className = 'sensor-value font-mono';
+    valueEl.textContent = '--';
+    valueEl.setAttribute('data-topic', s.path);
+    valueEl.setAttribute('data-static', '');
+    if (s.unit) valueEl.setAttribute('data-unit', s.unit);
+    card.innerHTML = `<span>${s.name}</span>`;
+    card.appendChild(valueEl);
+    if (s.unit) {
+      const unitSpan = document.createElement('span');
+      unitSpan.className = 'ml-1';
+      unitSpan.textContent = s.unit;
+      card.appendChild(unitSpan);
+    }
+    container.appendChild(card);
+    sensorValueEls[s.path] = valueEl;
+    topics.add(s.path);
+  });
+}
 
+function addRoofControls() {
+  const container = document.getElementById('roofControls');
+  if (roof.open.path) {
+    const openDiv = document.createElement('div');
+    openDiv.className = 'p-4 bg-white rounded shadow flex items-center justify-between';
+    openDiv.innerHTML = `<span>Open Roof</span><button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="${roof.open.path}"><span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span></button>`;
+    container.appendChild(openDiv);
+    topics.add(roof.open.path);
+  }
+  if (roof.close.path) {
+    const closeDiv = document.createElement('div');
+    closeDiv.className = 'p-4 bg-white rounded shadow flex items-center justify-between';
+    closeDiv.innerHTML = `<span>Close Roof</span><button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="${roof.close.path}"><span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span></button>`;
+    container.appendChild(closeDiv);
+    topics.add(roof.close.path);
+  }
+  if (roof.open.limit) {
+    const openLimitDiv = document.createElement('div');
+    openLimitDiv.className = 'p-4 bg-white rounded shadow flex items-center';
+    openLimitDiv.innerHTML = `<span class="mr-2">Open Limit</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.open.limit}" data-static></span>`;
+    container.appendChild(openLimitDiv);
+    indicatorEls[roof.open.limit] = openLimitDiv.querySelector('span[data-topic]');
+    topics.add(roof.open.limit);
+  }
+  if (roof.close.limit) {
+    const closeLimitDiv = document.createElement('div');
+    closeLimitDiv.className = 'p-4 bg-white rounded shadow flex items-center';
+    closeLimitDiv.innerHTML = `<span class="mr-2">Close Limit</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.close.limit}" data-static></span>`;
+    container.appendChild(closeLimitDiv);
+    indicatorEls[roof.close.limit] = closeLimitDiv.querySelector('span[data-topic]');
+    topics.add(roof.close.limit);
+  }
+}
+
+function addSwitchCards() {
+  const container = document.getElementById('switchesContainer');
+  switches.forEach(sw => {
+    const card = document.createElement('div');
+    card.className = 'p-4 bg-white rounded shadow flex items-center justify-between';
+    card.innerHTML = `<span>${sw.name}</span><button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="${sw.path}"><span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span></button>`;
+    container.appendChild(card);
+    topics.add(sw.path);
+  });
+}
+
+addSensorCards();
+addRoofControls();
+addSwitchCards();
+
+const topicElements = Array.from(document.querySelectorAll('[data-topic]'));
+const staticTopics = new Set(
+  topicElements.filter(el => el.hasAttribute('data-static')).map(el => el.getAttribute('data-topic'))
+);
 
 function setToggleDisabled(disabled) {
   document.querySelectorAll('.toggleButton').forEach(button => {
@@ -292,6 +202,37 @@ function updateConnectionStatus(status, info) {
 }
 setToggleDisabled(true);
 
+function createBullet(id, title, min, max, target, color, neg) {
+  return Highcharts.chart(id, {
+    chart: { type: 'bullet', inverted: true },
+    title: { text: title, align: 'left' },
+    xAxis: { categories: [''], title: null },
+    yAxis: { min: min, max: max, title: null, plotBands: [] },
+    series: [{
+      data: [{ y: 0, target: target }],
+      threshold: target,
+      color: color,
+      negativeColor: neg
+    }],
+    tooltip: { enabled: false },
+    credits: { enabled: false }
+  });
+}
+
+const bulletConfigs = {
+  'Observatory/Graph/clouds': { id: 'bullet-clouds', title: 'Clouds', min: -40, max: 40, target: -12, color: 'red', neg: 'green' },
+  'Observatory/Graph/light': { id: 'bullet-light', title: 'Light', min: 0, max: 20000, target: 10000, color: 'green', neg: 'red' },
+  'Observatory/Graph/rain': { id: 'bullet-rain', title: 'Rain', min: 0, max: 10000, target: 4200, color: 'green', neg: 'red' },
+  'Observatory/Graph/hum': { id: 'bullet-hum', title: 'Humidity', min: 0, max: 100, target: 95, color: 'red', neg: 'green' },
+  'Observatory/Graph/sqm': { id: 'bullet-sqm', title: 'Darkness', min: 0, max: 22, target: 15, color: 'green', neg: 'red' }
+};
+
+const bulletCharts = {};
+Object.entries(bulletConfigs).forEach(([topic, cfg]) => {
+  bulletCharts[topic] = createBullet(cfg.id, cfg.title, cfg.min, cfg.max, cfg.target, cfg.color, cfg.neg);
+  topics.add(topic);
+});
+
 if (mqttClient) {
   mqttClient.on('status', updateConnectionStatus);
   mqttClient.on('error', err => console.error('MQTT client error:', err));
@@ -305,16 +246,16 @@ if (mqttClient) {
 
   mqttClient.on('message', function(topic, message) {
     const value = message.toString();
-    if (gaugeCharts[topic]) {
-      const point = gaugeCharts[topic].series[0].points[0];
-      point.update(parseFloat(value));
+    if (sensorValueEls[topic]) {
+      const el = sensorValueEls[topic];
+      el.textContent = value;
+      const unit = el.getAttribute('data-unit');
+      if (unit) el.textContent = value + ' ' + unit;
     }
+    if (indicatorEls[topic]) updateIndicatorEl(indicatorEls[topic], value);
     if (bulletCharts[topic]) {
-      const chart = bulletCharts[topic];
-      chart.series[0].points[0].update({ y: parseFloat(value) });
+      bulletCharts[topic].series[0].points[0].update({ y: parseFloat(value) });
     }
-    if (topic === 'Observatory/roof/openlimit') updateIndicator('openLimitIndicator', value);
-    if (topic === 'Observatory/roof/closelimit') updateIndicator('closeLimitIndicator', value);
     if (!staticTopics.has(topic)) {
       toggleStates[topic] = value;
       updateToggleButton(topic, value);
@@ -330,9 +271,7 @@ if (mqttClient) {
   });
 }
 
-function updateIndicator(id, value) {
-  const el = document.getElementById(id);
-  if (!el) return;
+function updateIndicatorEl(el, value) {
   el.classList.remove('bg-green-500','bg-red-500','bg-gray-400');
   el.classList.add(value === '1' ? 'bg-green-500' : 'bg-red-500');
 }
@@ -352,15 +291,6 @@ function updateToggleButton(topic, value) {
     }
   }
 }
-</script>
-
-<script>
-function refreshImage() {
-  const image = document.getElementById('liveImage');
-  const timestamp = new Date().getTime();
-  image.src = 'http://skycam.local/current/tmp/image.jpg?' + timestamp;
-}
-setInterval(refreshImage, 120000);
 </script>
 </body>
 </html>

--- a/js/mqttConfig.js
+++ b/js/mqttConfig.js
@@ -9,6 +9,9 @@ export async function loadConfig() {
     port: parseInt(data.port, 10),
     username: data.username,
     password: data.password,
-    dashboardTopics: data.dashboardTopics
+    dashboardTopics: data.dashboardTopics,
+    sensors: data.sensors || [],
+    switches: data.switches || [],
+    roof: data.roof || { open: { path: '', limit: '' }, close: { path: '', limit: '' } }
   };
 }

--- a/save_config.php
+++ b/save_config.php
@@ -25,5 +25,23 @@ foreach ($allowed as $key) {
     }
 }
 
+if (isset($input['sensors']) && is_array($input['sensors'])) {
+    replaceSensors($input['sensors']);
+}
+
+if (isset($input['switches']) && is_array($input['switches'])) {
+    replaceSwitches($input['switches']);
+}
+
+if (isset($input['roof']) && is_array($input['roof'])) {
+    $roof = [
+        'open_path' => $input['roof']['open']['path'] ?? '',
+        'open_limit' => $input['roof']['open']['limit'] ?? '',
+        'close_path' => $input['roof']['close']['path'] ?? '',
+        'close_limit' => $input['roof']['close']['limit'] ?? ''
+    ];
+    setRoof($roof);
+}
+
 echo json_encode(['status' => 'ok']);
 ?>

--- a/settings.html
+++ b/settings.html
@@ -5,54 +5,144 @@
   <title>Settings</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 min-h-screen flex items-center justify-center">
-  <div class="bg-white p-6 rounded shadow w-full max-w-md">
+<body class="bg-gray-100 min-h-screen flex items-center justify-center p-6">
+  <div class="bg-white p-6 rounded shadow w-full max-w-3xl">
     <h1 class="text-xl mb-4">Configuration</h1>
-    <form id="settingsForm" class="space-y-4">
-      <div>
-        <label class="block text-sm font-medium">MQTT Broker URL</label>
-        <input name="MQTT_BROKER_URL" class="mt-1 p-2 border w-full" />
-      </div>
-      <div>
-        <label class="block text-sm font-medium">MQTT Port</label>
-        <input name="MQTT_PORT" type="number" class="mt-1 p-2 border w-full" />
-      </div>
-      <div>
-        <label class="block text-sm font-medium">MQTT Username</label>
-        <input name="MQTT_USERNAME" class="mt-1 p-2 border w-full" />
-      </div>
-      <div>
-        <label class="block text-sm font-medium">MQTT Password</label>
-        <input name="MQTT_PASSWORD" type="password" class="mt-1 p-2 border w-full" />
-      </div>
-      <div>
-        <label class="block text-sm font-medium">Dashboard Topics (comma-separated)</label>
+    <form id="settingsForm" class="space-y-6">
+      <section>
+        <h2 class="text-lg font-semibold mb-2">MQTT Server</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label class="block text-sm font-medium">Host</label>
+            <input name="MQTT_BROKER_URL" class="mt-1 p-2 border w-full" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium">Port</label>
+            <input name="MQTT_PORT" type="number" class="mt-1 p-2 border w-full" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium">Username</label>
+            <input name="MQTT_USERNAME" class="mt-1 p-2 border w-full" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium">Password</label>
+            <input name="MQTT_PASSWORD" type="password" class="mt-1 p-2 border w-full" />
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-semibold mb-2">Sensors</h2>
+        <div id="sensorsList" class="space-y-2"></div>
+        <button type="button" id="addSensor" class="mt-2 bg-gray-200 px-2 py-1 rounded">Add Sensor</button>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-semibold mb-2">Roof</h2>
+        <div class="space-y-2">
+          <div class="flex space-x-2">
+            <input id="roofOpenPath" class="p-2 border flex-1" placeholder="Open Path" />
+            <input id="roofOpenLimit" class="p-2 border flex-1" placeholder="Open Limit" />
+          </div>
+          <div class="flex space-x-2">
+            <input id="roofClosePath" class="p-2 border flex-1" placeholder="Close Path" />
+            <input id="roofCloseLimit" class="p-2 border flex-1" placeholder="Close Limit" />
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-semibold mb-2">Switches</h2>
+        <div id="switchesList" class="space-y-2"></div>
+        <button type="button" id="addSwitch" class="mt-2 bg-gray-200 px-2 py-1 rounded">Add Switch</button>
+      </section>
+
+      <section>
+        <h2 class="text-lg font-semibold mb-2">Dashboard Topics (comma separated)</h2>
         <input name="MQTT_DASHBOARD_TOPICS" class="mt-1 p-2 border w-full" />
-      </div>
+      </section>
+
       <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded">Save</button>
     </form>
     <div id="status" class="mt-4 text-sm"></div>
   </div>
+
   <script type="module">
+    import { loadConfig } from './js/mqttConfig.js';
+
+    const sensorsList = document.getElementById('sensorsList');
+    const switchesList = document.getElementById('switchesList');
+
+    function createSensorRow(data = {}) {
+      const row = document.createElement('div');
+      row.className = 'flex space-x-2 sensor-row';
+      row.innerHTML = `
+        <input class="p-2 border flex-1 sensor-path" placeholder="Path" value="${data.path || ''}">
+        <input class="p-2 border w-24 sensor-unit" placeholder="Unit" value="${data.unit || ''}">
+        <input class="p-2 border flex-1 sensor-name" placeholder="Name" value="${data.name || ''}">
+        <button type="button" class="remove bg-red-500 text-white px-2 rounded">X</button>`;
+      row.querySelector('.remove').addEventListener('click', () => row.remove());
+      sensorsList.appendChild(row);
+    }
+
+    function createSwitchRow(data = {}) {
+      const row = document.createElement('div');
+      row.className = 'flex space-x-2 switch-row';
+      row.innerHTML = `
+        <input class="p-2 border flex-1 switch-path" placeholder="Path" value="${data.path || ''}">
+        <input class="p-2 border flex-1 switch-name" placeholder="Name" value="${data.name || ''}">
+        <button type="button" class="remove bg-red-500 text-white px-2 rounded">X</button>`;
+      row.querySelector('.remove').addEventListener('click', () => row.remove());
+      switchesList.appendChild(row);
+    }
+
+    document.getElementById('addSensor').addEventListener('click', () => createSensorRow());
+    document.getElementById('addSwitch').addEventListener('click', () => createSwitchRow());
+
     async function loadSettings() {
-      const res = await fetch('/get_config.php');
-      const cfg = await res.json();
-      const map = {
-        MQTT_BROKER_URL: cfg.brokerUrl,
-        MQTT_PORT: cfg.port,
-        MQTT_USERNAME: cfg.username,
-        MQTT_PASSWORD: cfg.password,
-        MQTT_DASHBOARD_TOPICS: cfg.dashboardTopics.join(',')
-      };
-      Object.entries(map).forEach(([k,v]) => {
-        document.querySelector(`[name="${k}"]`).value = v;
-      });
+      const cfg = await loadConfig();
+      document.querySelector('[name="MQTT_BROKER_URL"]').value = cfg.brokerUrl;
+      document.querySelector('[name="MQTT_PORT"]').value = cfg.port;
+      document.querySelector('[name="MQTT_USERNAME"]').value = cfg.username;
+      document.querySelector('[name="MQTT_PASSWORD"]').value = cfg.password;
+      document.querySelector('[name="MQTT_DASHBOARD_TOPICS"]').value = cfg.dashboardTopics.join(',');
+      cfg.sensors.forEach(s => createSensorRow(s));
+      cfg.switches.forEach(s => createSwitchRow(s));
+      document.getElementById('roofOpenPath').value = cfg.roof.open.path || '';
+      document.getElementById('roofOpenLimit').value = cfg.roof.open.limit || '';
+      document.getElementById('roofClosePath').value = cfg.roof.close.path || '';
+      document.getElementById('roofCloseLimit').value = cfg.roof.close.limit || '';
     }
     loadSettings();
 
     document.getElementById('settingsForm').addEventListener('submit', async (e) => {
       e.preventDefault();
-      const data = Object.fromEntries(new FormData(e.target).entries());
+      const data = {
+        MQTT_BROKER_URL: document.querySelector('[name="MQTT_BROKER_URL"]').value,
+        MQTT_PORT: document.querySelector('[name="MQTT_PORT"]').value,
+        MQTT_USERNAME: document.querySelector('[name="MQTT_USERNAME"]').value,
+        MQTT_PASSWORD: document.querySelector('[name="MQTT_PASSWORD"]').value,
+        MQTT_DASHBOARD_TOPICS: document.querySelector('[name="MQTT_DASHBOARD_TOPICS"]').value,
+        sensors: Array.from(document.querySelectorAll('.sensor-row')).map(r => ({
+          path: r.querySelector('.sensor-path').value,
+          unit: r.querySelector('.sensor-unit').value,
+          name: r.querySelector('.sensor-name').value
+        })),
+        switches: Array.from(document.querySelectorAll('.switch-row')).map(r => ({
+          path: r.querySelector('.switch-path').value,
+          name: r.querySelector('.switch-name').value
+        })),
+        roof: {
+          open: {
+            path: document.getElementById('roofOpenPath').value,
+            limit: document.getElementById('roofOpenLimit').value
+          },
+          close: {
+            path: document.getElementById('roofClosePath').value,
+            limit: document.getElementById('roofCloseLimit').value
+          }
+        }
+      };
       try {
         const res = await fetch('/save_config.php', {
           method: 'POST',


### PR DESCRIPTION
## Summary
- Switch to SQLite tables for sensors, switches and roof settings
- Load/save MQTT, sensor, switch and roof config via settings page
- Render dashboard sections dynamically from stored configuration

## Testing
- `npm test` *(fails: ENOENT: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac59f2bba4832e8bd9a39acd2f913e