### PR TITLE
Add sensor indicators with configurable thresholds and sidebar on settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@
 
 - Sensor data uses Highcharts solid gauges with Tailwind indicators; the SkyCam image sits in its own card.
 
+- Sensors include red/green status dots driven by per-sensor thresholds configurable in settings.
+
 - Use `js/mqttClient.js` for all MQTT connections instead of direct library calls.
 - Highcharts solid gauges require `highcharts-more.js` and are placed inside Tailwind card wrappers.
 - Main page background uses a subtle top-to-bottom gray gradient.

--- a/index.html
+++ b/index.html
@@ -82,6 +82,7 @@ try {
 }
 
 const sensorValueEls = {};
+const sensorIndicators = {};
 const indicatorEls = {};
 const topics = new Set(dashboardTopics);
 const toggleStates = {};
@@ -91,22 +92,28 @@ function addSensorCards() {
   sensors.forEach(s => {
     const card = document.createElement('div');
     card.className = 'p-4 bg-white rounded shadow flex items-center justify-between';
+
+    const left = document.createElement('span');
+    left.className = 'flex items-center';
+    const indicator = document.createElement('span');
+    indicator.className = 'h-3 w-3 rounded-full bg-red-500 mr-2';
+    left.appendChild(indicator);
+    const nameSpan = document.createElement('span');
+    nameSpan.textContent = s.name;
+    left.appendChild(nameSpan);
+    card.appendChild(left);
+
     const valueEl = document.createElement('span');
     valueEl.className = 'sensor-value font-mono';
     valueEl.textContent = '--';
     valueEl.setAttribute('data-topic', s.path);
     valueEl.setAttribute('data-static', '');
     if (s.unit) valueEl.setAttribute('data-unit', s.unit);
-    card.innerHTML = `<span>${s.name}</span>`;
     card.appendChild(valueEl);
-    if (s.unit) {
-      const unitSpan = document.createElement('span');
-      unitSpan.className = 'ml-1';
-      unitSpan.textContent = s.unit;
-      card.appendChild(unitSpan);
-    }
+
     container.appendChild(card);
     sensorValueEls[s.path] = valueEl;
+    sensorIndicators[s.path] = { el: indicator, green: parseFloat(s.green) };
     topics.add(s.path);
   });
 }
@@ -248,10 +255,10 @@ if (mqttClient) {
     const value = message.toString();
     if (sensorValueEls[topic]) {
       const el = sensorValueEls[topic];
-      el.textContent = value;
       const unit = el.getAttribute('data-unit');
-      if (unit) el.textContent = value + ' ' + unit;
+      el.textContent = unit ? value + ' ' + unit : value;
     }
+    if (sensorIndicators[topic]) updateSensorIndicator(topic, value);
     if (indicatorEls[topic]) updateIndicatorEl(indicatorEls[topic], value);
     if (bulletCharts[topic]) {
       bulletCharts[topic].series[0].points[0].update({ y: parseFloat(value) });
@@ -274,6 +281,19 @@ if (mqttClient) {
 function updateIndicatorEl(el, value) {
   el.classList.remove('bg-green-500','bg-red-500','bg-gray-400');
   el.classList.add(value === '1' ? 'bg-green-500' : 'bg-red-500');
+}
+
+function updateSensorIndicator(topic, value) {
+  const data = sensorIndicators[topic];
+  if (!data) return;
+  const num = parseFloat(value);
+  if (!isNaN(num) && !isNaN(data.green) && num <= data.green) {
+    data.el.classList.remove('bg-red-500');
+    data.el.classList.add('bg-green-500');
+  } else {
+    data.el.classList.remove('bg-green-500');
+    data.el.classList.add('bg-red-500');
+  }
 }
 
 function updateToggleButton(topic, value) {

--- a/settings.html
+++ b/settings.html
@@ -5,8 +5,23 @@
   <title>Settings</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-100 min-h-screen flex items-center justify-center p-6">
-  <div class="bg-white p-6 rounded shadow w-full max-w-3xl">
+<body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 flex">
+  <aside class="w-64 bg-gray-900 text-white flex-shrink-0 flex flex-col min-h-screen sticky top-0">
+    <div class="p-4 text-lg font-bold">Observatory Control Panel</div>
+    <nav class="px-2 flex-1">
+      <ul class="space-y-2">
+        <li><a class="block px-2 py-1 hover:bg-gray-700" href="http://10.0.179.242" target="_blank">AAGSolo</a></li>
+        <li><a class="block px-2 py-1 hover:bg-gray-700" href="http://data.smeird.com:3000/public-dashboards/9d4866d34e934549a20debd888358718?refresh=1m&from=now-24h&to=now&timezone=browser" target="_blank">Obs Graphs</a></li>
+        <li><a class="block px-2 py-1 hover:bg-gray-700" href="http://data.smeird.com:3000/public-dashboards/2ed28400ef714b6899a67ca635137a59" target="_blank">Weather</a></li>
+        <li><a class="block px-2 py-1 hover:bg-gray-700" href="http://ob.smeird.com" target="_blank">Public obs</a></li>
+        <li><a class="block px-2 py-1 hover:bg-gray-700" href="http://www.smeird.com" target="_blank">Public Weather</a></li>
+        <li><a class="block px-2 py-1 hover:bg-gray-700" href="https://clearoutside.com/forecast/51.81/-0.29" target="_blank">Night Forecast</a></li>
+        <li><a class="block px-2 py-1 hover:bg-gray-700" href="settings.html">Settings</a></li>
+      </ul>
+    </nav>
+  </aside>
+  <main class="flex-1 p-6">
+  <div class="bg-white p-6 rounded shadow w-full max-w-3xl mx-auto">
     <h1 class="text-xl mb-4">Configuration</h1>
     <form id="settingsForm" class="space-y-6">
       <section>
@@ -66,7 +81,7 @@
     </form>
     <div id="status" class="mt-4 text-sm"></div>
   </div>
-
+  </main>
   <script type="module">
     import { loadConfig } from './js/mqttConfig.js';
 
@@ -80,6 +95,7 @@
         <input class="p-2 border flex-1 sensor-path" placeholder="Path" value="${data.path || ''}">
         <input class="p-2 border w-24 sensor-unit" placeholder="Unit" value="${data.unit || ''}">
         <input class="p-2 border flex-1 sensor-name" placeholder="Name" value="${data.name || ''}">
+        <input class="p-2 border w-24 sensor-green" type="number" step="any" placeholder="Green" value="${data.green || ''}">
         <button type="button" class="remove bg-red-500 text-white px-2 rounded">X</button>`;
       row.querySelector('.remove').addEventListener('click', () => row.remove());
       sensorsList.appendChild(row);
@@ -126,7 +142,8 @@
         sensors: Array.from(document.querySelectorAll('.sensor-row')).map(r => ({
           path: r.querySelector('.sensor-path').value,
           unit: r.querySelector('.sensor-unit').value,
-          name: r.querySelector('.sensor-name').value
+          name: r.querySelector('.sensor-name').value,
+          green: r.querySelector('.sensor-green').value
         })),
         switches: Array.from(document.querySelectorAll('.switch-row')).map(r => ({
           path: r.querySelector('.switch-path').value,


### PR DESCRIPTION
## Summary
- add red/green sensor status indicators with configurable thresholds
- include sidebar navigation on settings page and remove duplicate sensor units
- persist per-sensor green thresholds in config database

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68ac738120ac832e91a1f853ae73916f