### PR TITLE
Handle missing sensor green_value column

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,4 +27,4 @@
 - Client-side config fetches should use absolute paths (e.g. `/get_config.php`) to ensure correct resolution from nested directories.
 
 - Configuration endpoints respond with JSON and proper `Content-Type` headers; client pages should surface server error messages.
-
+- Database migrations should verify column existence using `PRAGMA table_info` before attempting schema alterations.


### PR DESCRIPTION
## Summary
- Ensure the `sensors` table includes `green_value` by checking `PRAGMA table_info` and adding the column when absent
- Safeguard `getSensors` against failed queries
- Document migration approach in AGENTS guidelines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac76a8ee38832ea9557d904a3c070f