### PR TITLE
Update config path and redirect after settings save

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Web interface for monitoring and controlling a small observatory and related har
 The site depends on MQTT for live updates.
 
 ## MQTT Configuration
-Connection details are stored in a SQLite `config.db` database. Client-side scripts load these settings through `js/mqttConfig.js` which fetches `/get_config.php`.
+Connection details are stored in a SQLite `config.db` database located at `/var/www/data/config.db` outside the web root. Client-side scripts load these settings through `js/mqttConfig.js` which fetches `/get_config.php`.
 
 Use `settings.html` to edit values such as broker URL, port, username, password and dashboard topics. Changes are saved via `/save_config.php` and take effect immediately on subsequent page loads.

--- a/config.php
+++ b/config.php
@@ -1,6 +1,6 @@
 <?php
 function getDb() {
-    $db = new SQLite3(__DIR__ . '/config.db');
+    $db = new SQLite3('/var/www/data/config.db');
     // create tables for simple key/value settings as well as dynamic lists
     $db->exec('CREATE TABLE IF NOT EXISTS settings (key TEXT PRIMARY KEY, value TEXT)');
     $db->exec('CREATE TABLE IF NOT EXISTS sensors (id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT UNIQUE, unit TEXT, name TEXT, green_value TEXT)');

--- a/settings.html
+++ b/settings.html
@@ -167,7 +167,11 @@
           body: JSON.stringify(data)
         });
         const body = await res.json();
-        document.getElementById('status').textContent = res.ok ? 'Saved' : (body.error || 'Error');
+        if (res.ok) {
+          window.location.href = '/';
+        } else {
+          document.getElementById('status').textContent = body.error || 'Error';
+        }
       } catch {
         document.getElementById('status').textContent = 'Error';
       }


### PR DESCRIPTION
## Summary
- point database access to `/var/www/data/config.db` outside web root
- redirect to the dashboard after successful settings save
- document new configuration database location

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac796fc61c832ea99cbaa6e6bd075c