### PR TITLE
Ensure MQTT status handler receives current state

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,8 +263,10 @@ function addSensorCharts() {
 
 let mqttClient;
 try {
+  const url = new URL(brokerUrl);
+  if (port) url.port = port;
   mqttClient = createClient({
-    brokerUrl: `${brokerUrl}:${port}`,
+    brokerUrl: url.toString(),
     options: { username, password }
   });
   mqttClient.on('status', updateConnectionStatus);


### PR DESCRIPTION
## Summary
- Track MQTT client's current connection status and last error
- Immediately invoke new status listeners with the latest state
- Build MQTT broker URL with the URL API to avoid malformed connection strings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac7fb18050832eb2d79339f5823fe3