### PR TITLE
Add telescope icon linking home

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Removed obsolete `cold.html` panel.
 - Removed legacy PHP and HTML files (e.g. `script.php`, `manualjob.php`, `recipies.html`, `api.php.old`, `getvaluestatus.php.old`, `index.php.old`, `index2.php`, `base.css`).
 - Navigation links now live in a Tailwind-styled sidebar instead of a top bar.
+- Main header includes a telescope icon linking back to the home screen.
 - Toggle controls should use Tailwind switch-style buttons with a sliding knob.
 - Main layout uses a full-height flex container with a sticky sidebar and wider grid spacing.
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
 <body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 md:flex">
 <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden md:hidden"></div>
 <aside id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-gray-900 text-white transform -translate-x-full md:translate-x-0 md:relative md:flex-shrink-0 flex flex-col transition-transform duration-200 z-40">
-  <div class="p-4 text-lg font-bold">Observatory Control Panel</div>
+  <div class="p-4 text-lg font-bold flex items-center"><a href="/" class="mr-2">🔭</a>Observatory Control Panel</div>
   <nav class="px-2 flex-1">
     <ul class="space-y-2">
       <li><a class="block px-2 py-1 hover:bg-gray-700" href="http://10.0.179.242" target="_blank">AAGSolo</a></li>
@@ -28,7 +28,7 @@
 </aside>
 <div class="flex flex-col min-h-screen flex-1">
   <header class="md:hidden bg-gray-900 text-white p-4 flex items-center justify-between">
-    <div class="text-lg font-bold">Observatory Control Panel</div>
+    <div class="text-lg font-bold flex items-center"><a href="/" class="mr-2">🔭</a>Observatory Control Panel</div>
     <button id="menuButton" class="focus:outline-none">
       <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
     </button>

--- a/settings.html
+++ b/settings.html
@@ -7,7 +7,7 @@
 </head>
 <body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 flex">
   <aside class="w-64 bg-gray-900 text-white flex-shrink-0 flex flex-col min-h-screen sticky top-0">
-    <div class="p-4 text-lg font-bold">Observatory Control Panel</div>
+    <div class="p-4 text-lg font-bold flex items-center"><a href="/" class="mr-2">🔭</a>Observatory Control Panel</div>
     <nav class="px-2 flex-1">
       <ul class="space-y-2">
         <li><a class="block px-2 py-1 hover:bg-gray-700" href="http://10.0.179.242" target="_blank">AAGSolo</a></li>


### PR DESCRIPTION
## Summary
- Add telescope emoji icon linking to home in sidebar and mobile headers
- Document new header icon convention

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac834a0518832eb8ac391f3831b5f1