### PR TITLE
Handle MQTT offline events in client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
 
 - SkyCam image sits in a bottom card section.
 - MQTT helper now emits `status` events (`connecting`, `connected`, `disconnected`, `reconnecting`, `error`) and uses exponential backoff reconnects up to 30s.
+- MQTT helper now treats broker `offline` events the same as `close`, ensuring reconnection when the connection drops silently.
 - MQTT topics should be derived from DOM elements with `data-topic`; flag topics without UI colour changes using `data-static`.
 - MQTT connection settings now load from a SQLite `config.db` via `js/mqttConfig.js` fetching `/get_config.php`.
 - A `settings.html` page allows editing these values and persists them through `/save_config.php`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Web interface for monitoring and controlling a small observatory and related har
 
 - **Settings editor** (`settings.html`): allows updating MQTT connection details stored in the local SQLite database.
 
-The site depends on MQTT for live updates.
+The site depends on MQTT for live updates. The helper in `js/mqttClient.js` treats broker `offline` events the same as a `close`, prompting the UI to show "Reconnecting..." when the connection silently drops.
 
 ## MQTT Configuration
 Connection details are stored in a SQLite `config.db` database located at `/var/www/data/config.db` outside the web root. Client-side scripts load these settings through `js/mqttConfig.js` which fetches `/get_config.php`.

--- a/js/mqttClient.js
+++ b/js/mqttClient.js
@@ -37,7 +37,9 @@
         handlers.status.forEach(h => h('error', err));
       });
 
+      // Treat broker 'close' or 'offline' events as disconnects
       client.on('close', handleDisconnect);
+      client.on('offline', handleDisconnect);
     };
 
     const handleDisconnect = () => {


### PR DESCRIPTION
## Summary
- treat MQTT `offline` events the same as `close` so reconnection logic runs
- document offline handling in README and project guidelines

## Testing
- `node - <<'NODE' ... NODE`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac852a98f0832eadeea5c412ffb448