### PR TITLE
Initialize bullet chart variables before first use

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,8 @@ const sensorIndicators = {};
 const indicatorEls = {};
 const topics = new Set(dashboardTopics);
 const toggleStates = {};
+const bulletCharts = {};
+const bulletTargets = {};
 
 function addSensorCards() {
   const container = document.getElementById('sensorsContainer');
@@ -235,9 +237,6 @@ function createBullet(id, title, min, max, target) {
     credits: { enabled: false }
   });
 }
-
-const bulletCharts = {};
-const bulletTargets = {};
 
 function defaultRange(green) {
   const g = parseFloat(green);


### PR DESCRIPTION
## Summary
- Prevent ReferenceError by declaring `bulletCharts` and `bulletTargets` before calling `addSensorCharts`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac858c5230832e960866b85ac69327