### PR TITLE
Force MQTT reconnect on errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - SkyCam image sits in a bottom card section.
 - MQTT helper now emits `status` events (`connecting`, `connected`, `disconnected`, `reconnecting`, `error`) and uses exponential backoff reconnects up to 30s.
 - MQTT helper now treats broker `offline` events the same as `close`, ensuring reconnection when the connection drops silently.
+- MQTT helper's `error` handler forces a client close to trigger reconnection, calling `handleDisconnect` directly if already closed.
 - MQTT topics should be derived from DOM elements with `data-topic`; flag topics without UI colour changes using `data-static`.
 - MQTT connection settings now load from a SQLite `config.db` via `js/mqttConfig.js` fetching `/get_config.php`.
 - A `settings.html` page allows editing these values and persists them through `/save_config.php`.

--- a/js/mqttClient.js
+++ b/js/mqttClient.js
@@ -35,6 +35,15 @@
         lastError = err;
         currentStatus = 'error';
         handlers.status.forEach(h => h('error', err));
+        // Force a close to trigger reconnect logic. If the client is already
+        // closed, invoke the disconnect handler directly. Avoid interfering
+        // with an intentional end() call by respecting the ended flag.
+        if (ended) return;
+        if (client && !client.disconnected && !client.disconnecting) {
+          client.end();
+        } else {
+          handleDisconnect();
+        }
       });
 
       // Treat broker 'close' or 'offline' events as disconnects


### PR DESCRIPTION
## Summary
- force MQTT client to close and reconnect when an error occurs, respecting the ended flag
- document new error-handling behavior in project guidelines

## Testing
- `node -e "const {EventEmitter}=require('events');global.mqtt={connect(){const e=new EventEmitter();e.connected=false;e.disconnected=false;e.disconnecting=false;e.end=()=>{e.disconnecting=true;setImmediate(()=>{e.disconnecting=false;e.disconnected=true;e.emit('close');});};setImmediate(()=>e.emit('error',new Error('Host not found')));return e;}};const {createClient}=require('./js/mqttClient.js');const client=createClient({brokerUrl:'mqtt://invalid'});const start=Date.now();client.on('status',(s,i)=>{const t=((Date.now()-start)/1000).toFixed(1);console.log(t,s,i);});setTimeout(()=>client.end(),9000);" && echo DONE`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac865e545c832e83476c669721774a