### PR TITLE
Add sensor threshold direction dropdown

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - Sensor data uses Highcharts solid gauges with Tailwind indicators; the SkyCam image sits in its own card.
 
 - Sensors include red/green status dots driven by per-sensor thresholds configurable in settings.
+- Sensors now allow selecting if green status triggers when the value is above or below the threshold via a dropdown in settings.
 
 - Use `js/mqttClient.js` for all MQTT connections instead of direct library calls.
 - Highcharts solid gauges require `highcharts-more.js` and are placed inside Tailwind card wrappers.

--- a/index.html
+++ b/index.html
@@ -126,7 +126,7 @@ function addSensorCards() {
 
     container.appendChild(card);
     sensorValueEls[s.path] = valueEl;
-    sensorIndicators[s.path] = { el: indicator, green: parseFloat(s.green) };
+    sensorIndicators[s.path] = { el: indicator, green: parseFloat(s.green), direction: s.greenDirection || 'below' };
     topics.add(s.path);
   });
 }
@@ -256,7 +256,7 @@ function addSensorCharts() {
     const range = defaultRange(s.green);
     const target = parseFloat(s.green);
     bulletCharts[s.path] = createBullet(id, s.name, range.min, range.max, target);
-    bulletTargets[s.path] = target;
+    bulletTargets[s.path] = { target, direction: s.greenDirection || 'below' };
   });
 }
 
@@ -289,8 +289,11 @@ try {
     if (indicatorEls[topic]) updateIndicatorEl(indicatorEls[topic], value);
     if (bulletCharts[topic]) {
       const y = parseFloat(value);
-      const target = bulletTargets[topic];
-      const color = (!isNaN(target) && y <= target) ? 'green' : 'red';
+      const info = bulletTargets[topic];
+      const target = info.target;
+      const dir = info.direction;
+      const isGreen = (!isNaN(target) && (dir === 'above' ? y >= target : y <= target));
+      const color = isGreen ? 'green' : 'red';
       bulletCharts[topic].series[0].points[0].update({ y, color });
     }
     if (!staticTopics.has(topic)) {
@@ -322,12 +325,15 @@ function updateSensorIndicator(topic, value) {
   const data = sensorIndicators[topic];
   if (!data) return;
   const num = parseFloat(value);
-  if (!isNaN(num) && !isNaN(data.green) && num <= data.green) {
-    data.el.classList.remove('bg-red-500');
-    data.el.classList.add('bg-green-500');
-  } else {
-    data.el.classList.remove('bg-green-500');
-    data.el.classList.add('bg-red-500');
+  if (!isNaN(num) && !isNaN(data.green)) {
+    const isGreen = data.direction === 'above' ? num >= data.green : num <= data.green;
+    if (isGreen) {
+      data.el.classList.remove('bg-red-500');
+      data.el.classList.add('bg-green-500');
+    } else {
+      data.el.classList.remove('bg-green-500');
+      data.el.classList.add('bg-red-500');
+    }
   }
 }
 

--- a/settings.html
+++ b/settings.html
@@ -96,6 +96,10 @@
         <input class="p-2 border w-24 sensor-unit" placeholder="Unit" value="${data.unit || ''}">
         <input class="p-2 border flex-1 sensor-name" placeholder="Name" value="${data.name || ''}">
         <input class="p-2 border w-24 sensor-green" type="number" step="any" placeholder="Green" value="${data.green || ''}">
+        <select class="p-2 border w-28 sensor-direction">
+          <option value="below" ${data.greenDirection === 'above' ? '' : 'selected'}>Below</option>
+          <option value="above" ${data.greenDirection === 'above' ? 'selected' : ''}>Above</option>
+        </select>
         <button type="button" class="remove bg-red-500 text-white px-2 rounded">X</button>`;
       row.querySelector('.remove').addEventListener('click', () => row.remove());
       sensorsList.appendChild(row);
@@ -143,7 +147,8 @@
           path: r.querySelector('.sensor-path').value,
           unit: r.querySelector('.sensor-unit').value,
           name: r.querySelector('.sensor-name').value,
-          green: r.querySelector('.sensor-green').value
+          green: r.querySelector('.sensor-green').value,
+          greenDirection: r.querySelector('.sensor-direction').value
         })),
         switches: Array.from(document.querySelectorAll('.switch-row')).map(r => ({
           path: r.querySelector('.switch-path').value,


### PR DESCRIPTION
## Summary
- allow configuring whether sensor values above or below a threshold show green status
- persist sensor threshold direction in SQLite and apply it on dashboard indicators and bullet charts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac870320dc832eb6f770685e63c14e