### PR TITLE
feat: separate axes and green zone styles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - Sensors include red/green status dots driven by per-sensor thresholds configurable in settings.
 - Sensors now allow selecting if green status triggers when the value is above or below the threshold via a dropdown in settings.
 - Graphs use a single Highcharts line chart with one series per sensor instead of individual bullet charts.
+- Line chart gives each sensor its own Y axis and uses dotted segments when values fall outside the green threshold.
 
 - Use `js/mqttClient.js` for all MQTT connections instead of direct library calls.
 - Highcharts solid gauges require `highcharts-more.js` and are placed inside Tailwind card wrappers.

--- a/index.html
+++ b/index.html
@@ -223,12 +223,25 @@ function updateConnectionStatus(status, info) {
 setToggleDisabled(true);
 
 function initLineChart() {
-  const series = sensors.map(s => ({ name: s.name, data: [] }));
+  const yAxis = sensors.map((s, idx) => ({
+    title: { text: s.name },
+    opposite: idx % 2 === 1
+  }));
+  const series = sensors.map((s, idx) => {
+    const green = parseFloat(s.green);
+    let zones;
+    if (!isNaN(green)) {
+      zones = s.greenDirection === 'above'
+        ? [{ value: green, dashStyle: 'Dot' }, {}]
+        : [{ value: green }, { dashStyle: 'Dot' }];
+    }
+    return { name: s.name, data: [], yAxis: idx, zones };
+  });
   lineChart = Highcharts.chart('lineChart', {
     chart: { type: 'line' },
     title: { text: null },
     xAxis: { type: 'datetime' },
-    yAxis: { title: { text: null } },
+    yAxis,
     series,
     credits: { enabled: false }
   });


### PR DESCRIPTION
## Summary
- give each sensor line its own Y axis on the dashboard chart
- show dotted segments when values fall outside green thresholds
- document chart behavior in AGENTS guidelines

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68ac8c44086c832e86bcfeb943c584cb