### PR TITLE
Add dotted line legend to line chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,10 @@
   <section class="bg-white rounded shadow p-6">
     <h2 class="text-xl font-semibold mb-4">Graphs</h2>
     <div id="lineChart" class="h-96"></div>
+    <div class="flex items-center mt-2 text-xs text-gray-600">
+      <span class="w-4 border-t-2 border-gray-400 border-dotted mr-2"></span>
+      <span>Dotted segments indicate values outside the green threshold</span>
+    </div>
   </section>
 </main>
 


### PR DESCRIPTION
## Summary
- Add a small legend under the main line chart explaining that dotted segments denote values outside the green threshold

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acadac2a18832ebe10aa6bebaf444b