### PR TITLE
Round sensor values to one decimal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - MQTT connection status indicator sits at the bottom of the sidebar.
 
 - Sensor data uses Highcharts solid gauges with Tailwind indicators; the SkyCam image sits in its own card.
+- Sensor values are rounded to at most one decimal place before display.
 
 - Sensors include red/green status dots driven by per-sensor thresholds configurable in settings.
 - Sensors now allow selecting if green status triggers when the value is above or below the threshold via a dropdown in settings.

--- a/index.html
+++ b/index.html
@@ -273,25 +273,25 @@ try {
   });
 
   mqttClient.on('message', function(topic, message) {
-    const value = message.toString();
+    const rawValue = message.toString();
+    const num = parseFloat(rawValue);
+    const rounded = !isNaN(num) ? Math.round(num * 10) / 10 : null;
+    const displayValue = rounded !== null ? rounded.toString() : rawValue;
     if (sensorValueEls[topic]) {
       const el = sensorValueEls[topic];
       const unit = el.getAttribute('data-unit');
-      el.textContent = unit ? value + ' ' + unit : value;
+      el.textContent = unit ? displayValue + ' ' + unit : displayValue;
     }
-    if (sensorIndicators[topic]) updateSensorIndicator(topic, value);
-    if (indicatorEls[topic]) updateIndicatorEl(indicatorEls[topic], value);
-    if (lineSeries[topic]) {
-      const y = parseFloat(value);
-      if (!isNaN(y)) {
-        const series = lineSeries[topic];
-        const shift = series.data.length > 50;
-        series.addPoint([Date.now(), y], true, shift);
-      }
+    if (sensorIndicators[topic]) updateSensorIndicator(topic, displayValue);
+    if (indicatorEls[topic]) updateIndicatorEl(indicatorEls[topic], rawValue);
+    if (lineSeries[topic] && rounded !== null) {
+      const series = lineSeries[topic];
+      const shift = series.data.length > 50;
+      series.addPoint([Date.now(), rounded], true, shift);
     }
     if (!staticTopics.has(topic)) {
-      toggleStates[topic] = value;
-      updateToggleButton(topic, value);
+      toggleStates[topic] = rawValue;
+      updateToggleButton(topic, rawValue);
     }
   });
 


### PR DESCRIPTION
## Summary
- Round incoming sensor values to one decimal place before displaying or charting
- Document sensor value rounding in AGENTS guidelines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aec9dbec78832eb7dfafc28560e018