### PR TITLE
Clarify roof limit switch labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Sensor values are rounded to at most one decimal place before display.
 
 - Sensors include red/green status dots driven by per-sensor thresholds configurable in settings.
+- Roof limit indicators are labeled "Roof Open" and "Roof Closed" for clarity.
 - Sensors now allow selecting if green status triggers when the value is above or below the threshold via a dropdown in settings.
 - Graphs use a single Highcharts line chart with one series per sensor instead of individual bullet charts.
 - Line chart gives each sensor its own Y axis and uses dotted segments when values fall outside the green threshold.

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@ function addRoofControls() {
   if (roof.open.limit) {
     const openLimitDiv = document.createElement('div');
     openLimitDiv.className = 'p-4 bg-white rounded shadow flex items-center';
-    openLimitDiv.innerHTML = `<span class="mr-2">Open Limit</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.open.limit}" data-static></span>`;
+    openLimitDiv.innerHTML = `<span class="mr-2">Roof Open</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.open.limit}" data-static></span>`;
     container.appendChild(openLimitDiv);
     indicatorEls[roof.open.limit] = openLimitDiv.querySelector('span[data-topic]');
     topics.add(roof.open.limit);
@@ -161,7 +161,7 @@ function addRoofControls() {
   if (roof.close.limit) {
     const closeLimitDiv = document.createElement('div');
     closeLimitDiv.className = 'p-4 bg-white rounded shadow flex items-center';
-    closeLimitDiv.innerHTML = `<span class="mr-2">Close Limit</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.close.limit}" data-static></span>`;
+    closeLimitDiv.innerHTML = `<span class="mr-2">Roof Closed</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.close.limit}" data-static></span>`;
     container.appendChild(closeLimitDiv);
     indicatorEls[roof.close.limit] = closeLimitDiv.querySelector('span[data-topic]');
     topics.add(roof.close.limit);

--- a/settings.html
+++ b/settings.html
@@ -57,11 +57,11 @@
         <div class="space-y-2">
           <div class="flex space-x-2">
             <input id="roofOpenPath" class="p-2 border flex-1" placeholder="Open Path" />
-            <input id="roofOpenLimit" class="p-2 border flex-1" placeholder="Open Limit" />
+            <input id="roofOpenLimit" class="p-2 border flex-1" placeholder="Roof Open Status Topic" />
           </div>
           <div class="flex space-x-2">
             <input id="roofClosePath" class="p-2 border flex-1" placeholder="Close Path" />
-            <input id="roofCloseLimit" class="p-2 border flex-1" placeholder="Close Limit" />
+            <input id="roofCloseLimit" class="p-2 border flex-1" placeholder="Roof Closed Status Topic" />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Rename roof limit indicators to "Roof Open" and "Roof Closed" for clearer status
- Update settings placeholders to use roof open/closed status topics
- Document limit switch labeling convention in AGENTS guidelines

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/pi-roof/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aecf50bd3c832e8cb11045386edd82