### PR TITLE
Clarify roof limit switch labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Sensor values are rounded to at most one decimal place before display.
 
 - Sensors include red/green status dots driven by per-sensor thresholds configurable in settings.
+- Roof limit indicators show phrases like "Roof is open"/"Roof isn't open" and "Roof is closed"/"Roof isn't closed" based on switch state.
 - Sensors now allow selecting if green status triggers when the value is above or below the threshold via a dropdown in settings.
 - Graphs use a single Highcharts line chart with one series per sensor instead of individual bullet charts.
 - Line chart gives each sensor its own Y axis and uses dotted segments when values fall outside the green threshold.

--- a/index.html
+++ b/index.html
@@ -153,17 +153,25 @@ function addRoofControls() {
   if (roof.open.limit) {
     const openLimitDiv = document.createElement('div');
     openLimitDiv.className = 'p-4 bg-white rounded shadow flex items-center';
-    openLimitDiv.innerHTML = `<span class="mr-2">Open Limit</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.open.limit}" data-static></span>`;
+    openLimitDiv.innerHTML = `<span class="mr-2" data-role="label">Roof isn't open</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.open.limit}" data-static></span>`;
     container.appendChild(openLimitDiv);
-    indicatorEls[roof.open.limit] = openLimitDiv.querySelector('span[data-topic]');
+    indicatorEls[roof.open.limit] = {
+      indicator: openLimitDiv.querySelector('span[data-topic]'),
+      label: openLimitDiv.querySelector('span[data-role="label"]'),
+      type: 'open'
+    };
     topics.add(roof.open.limit);
   }
   if (roof.close.limit) {
     const closeLimitDiv = document.createElement('div');
     closeLimitDiv.className = 'p-4 bg-white rounded shadow flex items-center';
-    closeLimitDiv.innerHTML = `<span class="mr-2">Close Limit</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.close.limit}" data-static></span>`;
+    closeLimitDiv.innerHTML = `<span class="mr-2" data-role="label">Roof isn't closed</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.close.limit}" data-static></span>`;
     container.appendChild(closeLimitDiv);
-    indicatorEls[roof.close.limit] = closeLimitDiv.querySelector('span[data-topic]');
+    indicatorEls[roof.close.limit] = {
+      indicator: closeLimitDiv.querySelector('span[data-topic]'),
+      label: closeLimitDiv.querySelector('span[data-role="label"]'),
+      type: 'close'
+    };
     topics.add(roof.close.limit);
   }
 }
@@ -309,9 +317,17 @@ try {
   console.error('MQTT init error:', err);
 }
 
-function updateIndicatorEl(el, value) {
+function updateIndicatorEl(data, value) {
+  const el = data.indicator;
   el.classList.remove('bg-green-500','bg-red-500','bg-gray-400');
   el.classList.add(value === '1' ? 'bg-green-500' : 'bg-red-500');
+  if (data.label) {
+    if (data.type === 'open') {
+      data.label.textContent = value === '1' ? 'Roof is open' : "Roof isn't open";
+    } else if (data.type === 'close') {
+      data.label.textContent = value === '1' ? 'Roof is closed' : "Roof isn't closed";
+    }
+  }
 }
 
 function updateSensorIndicator(topic, value) {

--- a/settings.html
+++ b/settings.html
@@ -57,11 +57,11 @@
         <div class="space-y-2">
           <div class="flex space-x-2">
             <input id="roofOpenPath" class="p-2 border flex-1" placeholder="Open Path" />
-            <input id="roofOpenLimit" class="p-2 border flex-1" placeholder="Open Limit" />
+            <input id="roofOpenLimit" class="p-2 border flex-1" placeholder="Roof Open Status Topic" />
           </div>
           <div class="flex space-x-2">
             <input id="roofClosePath" class="p-2 border flex-1" placeholder="Close Path" />
-            <input id="roofCloseLimit" class="p-2 border flex-1" placeholder="Close Limit" />
+            <input id="roofCloseLimit" class="p-2 border flex-1" placeholder="Roof Closed Status Topic" />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Dynamically show roof state text that switches between “Roof is open/isn't open” and “Roof is closed/isn't closed” based on limit switch state
- Document the new dynamic roof state phrasing in project guidelines

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/pi-roof/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aecf50bd3c832e8cb11045386edd82