### PR TITLE
Add dark mode toggle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,5 @@
 
 - Configuration endpoints respond with JSON and proper `Content-Type` headers; client pages should surface server error messages.
 - Database migrations should verify column existence using `PRAGMA table_info` before attempting schema alterations.
+
+- Dark mode is toggled via a sidebar switch storing preference in `localStorage` and applying Tailwind `dark:` classes on the `<html>` element.

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <script src="js/mqttClient.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 </head>
-<body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 md:flex">
+<body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 md:flex dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100">
 <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden md:hidden"></div>
 <aside id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-gray-900 text-white transform -translate-x-full md:translate-x-0 md:relative md:flex-shrink-0 flex flex-col transition-transform duration-200 z-40">
   <div class="p-4 text-lg font-bold flex items-center"><a href="/" class="mr-2">🔭</a>Observatory Control Panel</div>
@@ -24,7 +24,13 @@
       <li><a class="block px-2 py-1 hover:bg-gray-700" href="settings.html">Settings</a></li>
     </ul>
   </nav>
-  <div id="connectionStatus" class="p-4 text-sm flex items-center text-gray-300">
+  <div class="p-4 flex items-center justify-between">
+    <span class="text-sm">Dark Mode</span>
+    <button id="darkModeToggle" class="relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200">
+      <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
+    </button>
+  </div>
+  <div id="connectionStatus" class="p-4 text-sm flex items-center text-gray-300 dark:text-gray-400">
     <span id="statusDot" class="h-2 w-2 rounded-full bg-yellow-500 mr-2"></span>
     <span id="statusText">Connecting...</span>
   </div>
@@ -37,31 +43,31 @@
     </button>
   </header>
   <main class="flex-1 p-6 space-y-8">
-  <h1 class="text-3xl font-bold text-gray-900">Dashboard</h1>
+  <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">Dashboard</h1>
 
   <!-- Sensors -->
-  <section class="bg-white rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4">Sensors</h2>
+  <section class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
+    <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Sensors</h2>
     <div id="sensorsContainer" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"></div>
   </section>
 
   <!-- Roof -->
-  <section class="bg-white rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4">Roof Controls</h2>
+  <section class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
+    <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Roof Controls</h2>
     <div id="roofControls" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"></div>
   </section>
 
   <!-- Switches -->
-  <section class="bg-white rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4">Switches</h2>
+  <section class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
+    <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Switches</h2>
     <div id="switchesContainer" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"></div>
   </section>
 
   <!-- Graphs -->
-  <section class="bg-white rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4">Graphs</h2>
+  <section class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
+    <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Graphs</h2>
     <div id="lineChart" class="h-96"></div>
-    <div class="flex items-center mt-2 text-xs text-gray-600">
+    <div class="flex items-center mt-2 text-xs text-gray-600 dark:text-gray-400">
       <span class="w-4 border-t-2 border-gray-400 border-dotted mr-2"></span>
       <span>Dotted segments indicate values outside the green threshold</span>
     </div>
@@ -76,6 +82,7 @@ import { loadConfig } from './js/mqttConfig.js';
 const menuButton = document.getElementById('menuButton');
 const sidebar = document.getElementById('sidebar');
 const overlay = document.getElementById('overlay');
+const darkModeToggle = document.getElementById('darkModeToggle');
 if (menuButton && sidebar && overlay) {
   const toggleSidebar = () => {
     sidebar.classList.toggle('-translate-x-full');
@@ -83,6 +90,23 @@ if (menuButton && sidebar && overlay) {
   };
   menuButton.addEventListener('click', toggleSidebar);
   overlay.addEventListener('click', toggleSidebar);
+}
+
+if (darkModeToggle) {
+  const isDark = localStorage.getItem('theme') === 'dark';
+  if (isDark) {
+    document.documentElement.classList.add('dark');
+    darkModeToggle.classList.remove('bg-gray-200');
+    darkModeToggle.classList.add('bg-green-500');
+    darkModeToggle.querySelector('span')?.classList.add('translate-x-5');
+  }
+  darkModeToggle.addEventListener('click', () => {
+    const enabled = document.documentElement.classList.toggle('dark');
+    darkModeToggle.classList.toggle('bg-green-500', enabled);
+    darkModeToggle.classList.toggle('bg-gray-200', !enabled);
+    darkModeToggle.querySelector('span')?.classList.toggle('translate-x-5');
+    localStorage.setItem('theme', enabled ? 'dark' : 'light');
+  });
 }
 
 let brokerUrl, port, username, password, dashboardTopics, sensors, switches, roof;
@@ -107,7 +131,7 @@ function addSensorCards() {
   const container = document.getElementById('sensorsContainer');
   sensors.forEach(s => {
     const card = document.createElement('div');
-    card.className = 'p-4 bg-white rounded shadow flex items-center justify-between';
+    card.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center justify-between';
 
     const left = document.createElement('span');
     left.className = 'flex items-center';
@@ -138,21 +162,21 @@ function addRoofControls() {
   const container = document.getElementById('roofControls');
   if (roof.open.path) {
     const openDiv = document.createElement('div');
-    openDiv.className = 'p-4 bg-white rounded shadow flex items-center justify-between';
+    openDiv.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center justify-between';
     openDiv.innerHTML = `<span>Open Roof</span><button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="${roof.open.path}"><span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span></button>`;
     container.appendChild(openDiv);
     topics.add(roof.open.path);
   }
   if (roof.close.path) {
     const closeDiv = document.createElement('div');
-    closeDiv.className = 'p-4 bg-white rounded shadow flex items-center justify-between';
+    closeDiv.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center justify-between';
     closeDiv.innerHTML = `<span>Close Roof</span><button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="${roof.close.path}"><span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span></button>`;
     container.appendChild(closeDiv);
     topics.add(roof.close.path);
   }
   if (roof.open.limit) {
     const openLimitDiv = document.createElement('div');
-    openLimitDiv.className = 'p-4 bg-white rounded shadow flex items-center';
+    openLimitDiv.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center';
 
     openLimitDiv.innerHTML = `<span class="mr-2" data-role="label">Roof isn't open</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.open.limit}" data-static></span>`;
 
@@ -166,7 +190,7 @@ function addRoofControls() {
   }
   if (roof.close.limit) {
     const closeLimitDiv = document.createElement('div');
-    closeLimitDiv.className = 'p-4 bg-white rounded shadow flex items-center';
+    closeLimitDiv.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center';
 
     closeLimitDiv.innerHTML = `<span class="mr-2" data-role="label">Roof isn't closed</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.close.limit}" data-static></span>`;
 
@@ -184,7 +208,7 @@ function addSwitchCards() {
   const container = document.getElementById('switchesContainer');
   switches.forEach(sw => {
     const card = document.createElement('div');
-    card.className = 'p-4 bg-white rounded shadow flex items-center justify-between';
+    card.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center justify-between';
     card.innerHTML = `<span>${sw.name}</span><button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200" data-topic="${sw.path}"><span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span></button>`;
     container.appendChild(card);
     topics.add(sw.path);

--- a/settings.html
+++ b/settings.html
@@ -5,7 +5,7 @@
   <title>Settings</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 flex">
+<body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 flex dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100">
   <aside class="w-64 bg-gray-900 text-white flex-shrink-0 flex flex-col min-h-screen sticky top-0">
     <div class="p-4 text-lg font-bold flex items-center"><a href="/" class="mr-2">🔭</a>Observatory Control Panel</div>
     <nav class="px-2 flex-1">
@@ -19,13 +19,19 @@
         <li><a class="block px-2 py-1 hover:bg-gray-700" href="settings.html">Settings</a></li>
       </ul>
     </nav>
+    <div class="p-4 flex items-center justify-between">
+      <span class="text-sm">Dark Mode</span>
+      <button id="darkModeToggle" class="relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200">
+        <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
+      </button>
+    </div>
   </aside>
   <main class="flex-1 p-6">
-  <div class="bg-white p-6 rounded shadow w-full max-w-3xl mx-auto">
-    <h1 class="text-xl mb-4">Configuration</h1>
+  <div class="bg-white dark:bg-gray-700 dark:text-gray-200 p-6 rounded shadow w-full max-w-3xl mx-auto">
+    <h1 class="text-xl mb-4 text-gray-900 dark:text-gray-100">Configuration</h1>
     <form id="settingsForm" class="space-y-6">
       <section>
-        <h2 class="text-lg font-semibold mb-2">MQTT Server</h2>
+        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">MQTT Server</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div>
             <label class="block text-sm font-medium">Host</label>
@@ -47,13 +53,13 @@
       </section>
 
       <section>
-        <h2 class="text-lg font-semibold mb-2">Sensors</h2>
+        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">Sensors</h2>
         <div id="sensorsList" class="space-y-2"></div>
         <button type="button" id="addSensor" class="mt-2 bg-gray-200 px-2 py-1 rounded">Add Sensor</button>
       </section>
 
       <section>
-        <h2 class="text-lg font-semibold mb-2">Roof</h2>
+        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">Roof</h2>
         <div class="space-y-2">
           <div class="flex space-x-2">
             <input id="roofOpenPath" class="p-2 border flex-1" placeholder="Open Path" />
@@ -67,13 +73,13 @@
       </section>
 
       <section>
-        <h2 class="text-lg font-semibold mb-2">Switches</h2>
+        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">Switches</h2>
         <div id="switchesList" class="space-y-2"></div>
         <button type="button" id="addSwitch" class="mt-2 bg-gray-200 px-2 py-1 rounded">Add Switch</button>
       </section>
 
       <section>
-        <h2 class="text-lg font-semibold mb-2">Dashboard Topics (comma separated)</h2>
+        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">Dashboard Topics (comma separated)</h2>
         <input name="MQTT_DASHBOARD_TOPICS" class="mt-1 p-2 border w-full" />
       </section>
 
@@ -84,6 +90,24 @@
   </main>
   <script type="module">
     import { loadConfig } from './js/mqttConfig.js';
+
+    const darkModeToggle = document.getElementById('darkModeToggle');
+    if (darkModeToggle) {
+      const isDark = localStorage.getItem('theme') === 'dark';
+      if (isDark) {
+        document.documentElement.classList.add('dark');
+        darkModeToggle.classList.remove('bg-gray-200');
+        darkModeToggle.classList.add('bg-green-500');
+        darkModeToggle.querySelector('span')?.classList.add('translate-x-5');
+      }
+      darkModeToggle.addEventListener('click', () => {
+        const enabled = document.documentElement.classList.toggle('dark');
+        darkModeToggle.classList.toggle('bg-green-500', enabled);
+        darkModeToggle.classList.toggle('bg-gray-200', !enabled);
+        darkModeToggle.querySelector('span')?.classList.toggle('translate-x-5');
+        localStorage.setItem('theme', enabled ? 'dark' : 'light');
+      });
+    }
 
     const sensorsList = document.getElementById('sensorsList');
     const switchesList = document.getElementById('switchesList');


### PR DESCRIPTION
## Summary
- Add sidebar switch to toggle dark mode and persist preference
- Style dashboard and settings sections with Tailwind `dark:` classes
- Document dark mode approach in AGENTS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aee3def360832eace4a148047bc45c