### PR TITLE
Highlight sensors card when all readings are green

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@
 
 - Sensors include red/green status dots driven by per-sensor thresholds configurable in settings.
 
+- When all sensors indicate green, the sensors card shows a green border.
+
 - Roof limit indicators show phrases like "Roof is open"/"Roof isn't open" and "Roof is closed"/"Roof isn't closed" based on switch state.
 
 - Sensors now allow selecting if green status triggers when the value is above or below the threshold via a dropdown in settings.

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
   <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">Dashboard</h1>
 
   <!-- Sensors -->
-  <section class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
+  <section id="sensorCard" class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
     <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Sensors</h2>
     <div id="sensorsContainer" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"></div>
   </section>
@@ -126,6 +126,7 @@ const topics = new Set(dashboardTopics);
 const toggleStates = {};
 let lineChart;
 const lineSeries = {};
+const sensorCard = document.getElementById('sensorCard');
 
 function addSensorCards() {
   const container = document.getElementById('sensorsContainer');
@@ -153,7 +154,12 @@ function addSensorCards() {
 
     container.appendChild(card);
     sensorValueEls[s.path] = valueEl;
-    sensorIndicators[s.path] = { el: indicator, green: parseFloat(s.green), direction: s.greenDirection || 'below' };
+    sensorIndicators[s.path] = {
+      el: indicator,
+      green: parseFloat(s.green),
+      direction: s.greenDirection || 'below',
+      isGreen: false
+    };
     topics.add(s.path);
   });
 }
@@ -364,12 +370,25 @@ function updateSensorIndicator(topic, value) {
   const num = parseFloat(value);
   if (!isNaN(num) && !isNaN(data.green)) {
     const isGreen = data.direction === 'above' ? num >= data.green : num <= data.green;
+    data.isGreen = isGreen;
     if (isGreen) {
       data.el.classList.remove('bg-red-500');
       data.el.classList.add('bg-green-500');
     } else {
       data.el.classList.remove('bg-green-500');
       data.el.classList.add('bg-red-500');
+    }
+  } else {
+    data.isGreen = false;
+  }
+
+  if (sensorCard) {
+    const allGreen = Object.values(sensorIndicators).length > 0 &&
+      Object.values(sensorIndicators).every(s => s.isGreen);
+    if (allGreen) {
+      sensorCard.classList.add('border-2', 'border-green-500');
+    } else {
+      sensorCard.classList.remove('border-2', 'border-green-500');
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `sensorCard` section id and state tracking to identify when all sensors report green
- Toggle green border on sensor card whenever every sensor indicator is green
- Document new behavior in AGENTS guidelines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b22f0e9a50832e9643951c9adebf5e