### PR TITLE
Add SkyCam MQTT image and configurable topic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
 - Main page background uses a subtle top-to-bottom gray gradient.
 
 - SkyCam image sits in a bottom card section.
+- SkyCam image loads from an MQTT topic configured in settings (`MQTT_SKYCAM_TOPIC`).
 - MQTT helper now emits `status` events (`connecting`, `connected`, `disconnected`, `reconnecting`, `error`) and uses exponential backoff reconnects up to 30s.
 - MQTT helper now treats broker `offline` events the same as `close`, ensuring reconnection when the connection drops silently.
 - MQTT helper's `error` handler forces a client close to trigger reconnection, calling `handleDisconnect` directly if already closed.

--- a/get_config.php
+++ b/get_config.php
@@ -6,7 +6,8 @@ $defaults = [
     'MQTT_PORT' => '1884',
     'MQTT_USERNAME' => '',
     'MQTT_PASSWORD' => '',
-    'MQTT_DASHBOARD_TOPICS' => ''
+    'MQTT_DASHBOARD_TOPICS' => '',
+    'MQTT_SKYCAM_TOPIC' => ''
 ];
 
 $stored = getAllSettings();
@@ -23,6 +24,7 @@ echo json_encode([
     'port' => (int)$config['MQTT_PORT'],
     'username' => $config['MQTT_USERNAME'],
     'password' => $config['MQTT_PASSWORD'],
+    'skyCamTopic' => $config['MQTT_SKYCAM_TOPIC'],
     'dashboardTopics' => array_values(array_filter(explode(',', $config['MQTT_DASHBOARD_TOPICS']))),
     'sensors' => getSensors(),
     'switches' => getSwitches(),

--- a/index.html
+++ b/index.html
@@ -72,6 +72,12 @@
       <span>Dotted segments indicate values outside the green threshold</span>
     </div>
   </section>
+
+  <!-- SkyCam -->
+  <section id="skyCamCard" class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
+    <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">SkyCam</h2>
+    <img id="skyCamImage" class="w-full h-auto rounded" alt="SkyCam" />
+  </section>
 </main>
 
 </div>
@@ -109,9 +115,9 @@ if (darkModeToggle) {
   });
 }
 
-let brokerUrl, port, username, password, dashboardTopics, sensors, switches, roof;
+let brokerUrl, port, username, password, dashboardTopics, sensors, switches, roof, skyCamTopic;
 try {
-  ({ brokerUrl, port, username, password, dashboardTopics, sensors, switches, roof } = await loadConfig());
+  ({ brokerUrl, port, username, password, dashboardTopics, sensors, switches, roof, skyCamTopic } = await loadConfig());
 } catch (err) {
   const statusEl = document.getElementById('statusText');
   if (statusEl) statusEl.textContent = 'Error connecting to MQTT';
@@ -123,6 +129,15 @@ const sensorValueEls = {};
 const sensorIndicators = {};
 const indicatorEls = {};
 const topics = new Set(dashboardTopics);
+const skyCamCard = document.getElementById('skyCamCard');
+const skyCamImage = document.getElementById('skyCamImage');
+if (skyCamTopic) {
+  topics.add(skyCamTopic);
+  skyCamImage?.setAttribute('data-topic', skyCamTopic);
+  skyCamImage?.setAttribute('data-static', '');
+} else {
+  skyCamCard?.classList.add('hidden');
+}
 const toggleStates = {};
 let lineChart;
 const lineSeries = {};
@@ -328,6 +343,17 @@ try {
   });
 
   mqttClient.on('message', function(topic, message) {
+    if (skyCamTopic && topic === skyCamTopic) {
+      if (skyCamImage) {
+        const blob = new Blob([message]);
+        const url = URL.createObjectURL(blob);
+        const prev = skyCamImage.dataset.url;
+        if (prev) URL.revokeObjectURL(prev);
+        skyCamImage.src = url;
+        skyCamImage.dataset.url = url;
+      }
+      return;
+    }
     const rawValue = message.toString();
     const num = parseFloat(rawValue);
     const rounded = !isNaN(num) ? Math.round(num * 10) / 10 : null;

--- a/js/mqttConfig.js
+++ b/js/mqttConfig.js
@@ -12,6 +12,7 @@ export async function loadConfig() {
     dashboardTopics: data.dashboardTopics,
     sensors: data.sensors || [],
     switches: data.switches || [],
-    roof: data.roof || { open: { path: '', limit: '' }, close: { path: '', limit: '' } }
+    roof: data.roof || { open: { path: '', limit: '' }, close: { path: '', limit: '' } },
+    skyCamTopic: data.skyCamTopic || ''
   };
 }

--- a/save_config.php
+++ b/save_config.php
@@ -9,7 +9,8 @@ $allowed = [
     'MQTT_PORT',
     'MQTT_USERNAME',
     'MQTT_PASSWORD',
-    'MQTT_DASHBOARD_TOPICS'
+    'MQTT_DASHBOARD_TOPICS',
+    'MQTT_SKYCAM_TOPIC'
 ];
 
 $input = json_decode(file_get_contents('php://input'), true);

--- a/settings.html
+++ b/settings.html
@@ -79,6 +79,11 @@
       </section>
 
       <section>
+        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">SkyCam Topic</h2>
+        <input name="MQTT_SKYCAM_TOPIC" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
+      </section>
+
+      <section>
         <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">Dashboard Topics (comma separated)</h2>
         <input name="MQTT_DASHBOARD_TOPICS" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
       </section>
@@ -149,6 +154,7 @@
       document.querySelector('[name="MQTT_PORT"]').value = cfg.port;
       document.querySelector('[name="MQTT_USERNAME"]').value = cfg.username;
       document.querySelector('[name="MQTT_PASSWORD"]').value = cfg.password;
+      document.querySelector('[name="MQTT_SKYCAM_TOPIC"]').value = cfg.skyCamTopic || '';
       document.querySelector('[name="MQTT_DASHBOARD_TOPICS"]').value = cfg.dashboardTopics.join(',');
       cfg.sensors.forEach(s => createSensorRow(s));
       cfg.switches.forEach(s => createSwitchRow(s));
@@ -166,6 +172,7 @@
         MQTT_PORT: document.querySelector('[name="MQTT_PORT"]').value,
         MQTT_USERNAME: document.querySelector('[name="MQTT_USERNAME"]').value,
         MQTT_PASSWORD: document.querySelector('[name="MQTT_PASSWORD"]').value,
+        MQTT_SKYCAM_TOPIC: document.querySelector('[name="MQTT_SKYCAM_TOPIC"]').value,
         MQTT_DASHBOARD_TOPICS: document.querySelector('[name="MQTT_DASHBOARD_TOPICS"]').value,
         sensors: Array.from(document.querySelectorAll('.sensor-row')).map(r => ({
           path: r.querySelector('.sensor-path').value,


### PR DESCRIPTION
## Summary
- display a SkyCam image on the dashboard that updates from a configurable MQTT topic
- allow configuring the SkyCam topic in settings and persist it via config APIs
- document new SkyCam MQTT setting in AGENTS guidelines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b400e08d18832e944b0ba366a0dc75