### PR TITLE
Make settings card full width

### DIFF
--- a/settings.html
+++ b/settings.html
@@ -27,7 +27,7 @@
     </div>
   </aside>
   <main class="flex-1 p-6">
-  <div class="bg-white dark:bg-gray-700 dark:text-gray-200 p-6 rounded shadow w-full max-w-3xl mx-auto">
+    <div class="bg-white dark:bg-gray-700 dark:text-gray-200 p-6 rounded shadow w-full">
     <h1 class="text-xl mb-4 text-gray-900 dark:text-gray-100">Configuration</h1>
     <form id="settingsForm" class="space-y-6">
       <section>


### PR DESCRIPTION
## Summary
- make the configuration card span the full width of the main area

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b40a8e12c4832ea96ed4718bbc354d