### PR TITLE
feat: make InfluxDB settings configurable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@
 - Sensors include red/green status dots driven by per-sensor thresholds configurable in settings.
 
 - Sensors may specify InfluxDB `influxMeasurement` and `influxField` values in settings to enable historical data charts. When present, the sensor card displays a history icon linking to `history.html`.
+- Global InfluxDB connection settings (host, organization, bucket) are editable in settings and returned via `get_config.php`.
 
 - When all sensors indicate green, the sensors card shows a green border.
 

--- a/get_config.php
+++ b/get_config.php
@@ -7,7 +7,10 @@ $defaults = [
     'MQTT_USERNAME' => '',
     'MQTT_PASSWORD' => '',
     'MQTT_DASHBOARD_TOPICS' => '',
-    'MQTT_SKYCAM_TOPIC' => ''
+    'MQTT_SKYCAM_TOPIC' => '',
+    'INFLUX_HOST' => 'http://localhost:8086',
+    'INFLUX_ORG' => 'primary',
+    'INFLUX_BUCKET' => 'Garden'
 ];
 
 $stored = getAllSettings();
@@ -26,6 +29,9 @@ echo json_encode([
     'password' => $config['MQTT_PASSWORD'],
     'skyCamTopic' => $config['MQTT_SKYCAM_TOPIC'],
     'dashboardTopics' => array_values(array_filter(explode(',', $config['MQTT_DASHBOARD_TOPICS']))),
+    'influxHost' => $config['INFLUX_HOST'],
+    'influxOrg' => $config['INFLUX_ORG'],
+    'influxBucket' => $config['INFLUX_BUCKET'],
     'sensors' => getSensors(),
     'switches' => getSwitches(),
     'roof' => [

--- a/history.html
+++ b/history.html
@@ -63,7 +63,7 @@
     }
 
     async function init() {
-      const { sensors } = await loadConfig();
+      const { sensors, influxHost, influxOrg, influxBucket } = await loadConfig();
       const sensor = sensors.find(s => s.path === sensorPath);
       if (!sensor || !sensor.influxMeasurement || !sensor.influxField) {
         document.getElementById('sensorTitle').textContent = 'No historical data';
@@ -79,9 +79,10 @@
 
       async function fetchData(rangeKey) {
         const { start, window } = ranges[rangeKey];
-        const flux = `from(bucket: "Garden")\n  |> range(start: ${start})\n  |> filter(fn: (r) => r["_measurement"] == "${sensor.influxMeasurement}")\n  |> filter(fn: (r) => r["_field"] == "${sensor.influxField}")\n  |> aggregateWindow(every: ${window}, fn: mean, createEmpty: false)\n  |> yield(name: "mean")`;
+        const flux = `from(bucket: "${influxBucket}")\n  |> range(start: ${start})\n  |> filter(fn: (r) => r["_measurement"] == "${sensor.influxMeasurement}")\n  |> filter(fn: (r) => r["_field"] == "${sensor.influxField}")\n  |> aggregateWindow(every: ${window}, fn: mean, createEmpty: false)\n  |> yield(name: "mean")`;
         try {
-          const res = await fetch('http://localhost:8086/api/v2/query?org=primary', {
+          const url = `${influxHost.replace(/\/$/, '')}/api/v2/query?org=${encodeURIComponent(influxOrg)}`;
+          const res = await fetch(url, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/vnd.flux',

--- a/js/mqttConfig.js
+++ b/js/mqttConfig.js
@@ -13,6 +13,9 @@ export async function loadConfig() {
     sensors: data.sensors || [],
     switches: data.switches || [],
     roof: data.roof || { open: { path: '', limit: '' }, close: { path: '', limit: '' } },
-    skyCamTopic: data.skyCamTopic || ''
+    skyCamTopic: data.skyCamTopic || '',
+    influxHost: data.influxHost,
+    influxOrg: data.influxOrg,
+    influxBucket: data.influxBucket
   };
 }

--- a/save_config.php
+++ b/save_config.php
@@ -10,7 +10,10 @@ $allowed = [
     'MQTT_USERNAME',
     'MQTT_PASSWORD',
     'MQTT_DASHBOARD_TOPICS',
-    'MQTT_SKYCAM_TOPIC'
+    'MQTT_SKYCAM_TOPIC',
+    'INFLUX_HOST',
+    'INFLUX_ORG',
+    'INFLUX_BUCKET'
 ];
 
 $input = json_decode(file_get_contents('php://input'), true);

--- a/settings.html
+++ b/settings.html
@@ -53,6 +53,24 @@
       </section>
 
       <section>
+        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">InfluxDB</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div>
+            <label class="block text-sm font-medium">Host</label>
+            <input name="INFLUX_HOST" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium">Org</label>
+            <input name="INFLUX_ORG" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium">Bucket</label>
+            <input name="INFLUX_BUCKET" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
+          </div>
+        </div>
+      </section>
+
+      <section>
         <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">Sensors</h2>
         <div id="sensorsList" class="space-y-2"></div>
         <button type="button" id="addSensor" class="mt-2 bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">Add Sensor</button>
@@ -158,6 +176,9 @@
       document.querySelector('[name="MQTT_PASSWORD"]').value = cfg.password;
       document.querySelector('[name="MQTT_SKYCAM_TOPIC"]').value = cfg.skyCamTopic || '';
       document.querySelector('[name="MQTT_DASHBOARD_TOPICS"]').value = cfg.dashboardTopics.join(',');
+      document.querySelector('[name="INFLUX_HOST"]').value = cfg.influxHost || '';
+      document.querySelector('[name="INFLUX_ORG"]').value = cfg.influxOrg || '';
+      document.querySelector('[name="INFLUX_BUCKET"]').value = cfg.influxBucket || '';
       cfg.sensors.forEach(s => createSensorRow(s));
       cfg.switches.forEach(s => createSwitchRow(s));
       document.getElementById('roofOpenPath').value = cfg.roof.open.path || '';
@@ -176,6 +197,9 @@
         MQTT_PASSWORD: document.querySelector('[name="MQTT_PASSWORD"]').value,
         MQTT_SKYCAM_TOPIC: document.querySelector('[name="MQTT_SKYCAM_TOPIC"]').value,
         MQTT_DASHBOARD_TOPICS: document.querySelector('[name="MQTT_DASHBOARD_TOPICS"]').value,
+        INFLUX_HOST: document.querySelector('[name="INFLUX_HOST"]').value,
+        INFLUX_ORG: document.querySelector('[name="INFLUX_ORG"]').value,
+        INFLUX_BUCKET: document.querySelector('[name="INFLUX_BUCKET"]').value,
         sensors: Array.from(document.querySelectorAll('.sensor-row')).map(r => ({
           path: r.querySelector('.sensor-path').value,
           unit: r.querySelector('.sensor-unit').value,


### PR DESCRIPTION
## Summary
- add InfluxDB host, org, bucket defaults to `get_config.php`
- allow saving and loading InfluxDB details and expose them in JS
- use configured InfluxDB details for history chart and settings form

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b40b11f444832ea1caf1388edb3002