### PR TITLE
Store InfluxDB token in settings

### DIFF
--- a/get_config.php
+++ b/get_config.php
@@ -10,7 +10,8 @@ $defaults = [
     'MQTT_SKYCAM_TOPIC' => '',
     'INFLUX_HOST' => 'http://localhost:8086',
     'INFLUX_ORG' => 'primary',
-    'INFLUX_BUCKET' => 'Garden'
+    'INFLUX_BUCKET' => 'Garden',
+    'INFLUX_TOKEN' => ''
 ];
 
 $stored = getAllSettings();
@@ -32,6 +33,7 @@ echo json_encode([
     'influxHost' => $config['INFLUX_HOST'],
     'influxOrg' => $config['INFLUX_ORG'],
     'influxBucket' => $config['INFLUX_BUCKET'],
+    'influxToken' => $config['INFLUX_TOKEN'],
     'sensors' => getSensors(),
     'switches' => getSwitches(),
     'roof' => [

--- a/history.html
+++ b/history.html
@@ -63,7 +63,7 @@
     }
 
     async function init() {
-      const { sensors, influxHost, influxOrg, influxBucket } = await loadConfig();
+      const { sensors, influxHost, influxOrg, influxBucket, influxToken } = await loadConfig();
       const sensor = sensors.find(s => s.path === sensorPath);
       if (!sensor || !sensor.influxMeasurement || !sensor.influxField) {
         document.getElementById('sensorTitle').textContent = 'No historical data';
@@ -86,7 +86,8 @@
             method: 'POST',
             headers: {
               'Content-Type': 'application/vnd.flux',
-              'Accept': 'application/csv'
+              'Accept': 'application/csv',
+              'Authorization': `Token ${influxToken}`
             },
             body: flux
           });

--- a/js/mqttConfig.js
+++ b/js/mqttConfig.js
@@ -16,6 +16,7 @@ export async function loadConfig() {
     skyCamTopic: data.skyCamTopic || '',
     influxHost: data.influxHost,
     influxOrg: data.influxOrg,
-    influxBucket: data.influxBucket
+    influxBucket: data.influxBucket,
+    influxToken: data.influxToken
   };
 }

--- a/save_config.php
+++ b/save_config.php
@@ -13,7 +13,8 @@ $allowed = [
     'MQTT_SKYCAM_TOPIC',
     'INFLUX_HOST',
     'INFLUX_ORG',
-    'INFLUX_BUCKET'
+    'INFLUX_BUCKET',
+    'INFLUX_TOKEN'
 ];
 
 $input = json_decode(file_get_contents('php://input'), true);

--- a/settings.html
+++ b/settings.html
@@ -56,7 +56,7 @@
 
       <section>
         <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">InfluxDB</h2>
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div class="grid grid-cols-1 sm:grid-cols-4 gap-4">
           <div>
             <label class="block text-sm font-medium">Host</label>
             <input name="INFLUX_HOST" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
@@ -68,6 +68,10 @@
           <div>
             <label class="block text-sm font-medium">Bucket</label>
             <input name="INFLUX_BUCKET" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium">Token</label>
+            <input name="INFLUX_TOKEN" type="password" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
           </div>
         </div>
       </section>
@@ -181,6 +185,7 @@
       document.querySelector('[name="INFLUX_HOST"]').value = cfg.influxHost || '';
       document.querySelector('[name="INFLUX_ORG"]').value = cfg.influxOrg || '';
       document.querySelector('[name="INFLUX_BUCKET"]').value = cfg.influxBucket || '';
+      document.querySelector('[name="INFLUX_TOKEN"]').value = cfg.influxToken || '';
       cfg.sensors.forEach(s => createSensorRow(s));
       cfg.switches.forEach(s => createSwitchRow(s));
       document.getElementById('roofOpenPath').value = cfg.roof.open.path || '';
@@ -202,6 +207,7 @@
         INFLUX_HOST: document.querySelector('[name="INFLUX_HOST"]').value,
         INFLUX_ORG: document.querySelector('[name="INFLUX_ORG"]').value,
         INFLUX_BUCKET: document.querySelector('[name="INFLUX_BUCKET"]').value,
+        INFLUX_TOKEN: document.querySelector('[name="INFLUX_TOKEN"]').value,
         sensors: Array.from(document.querySelectorAll('.sensor-row')).map(r => ({
           path: r.querySelector('.sensor-path').value,
           unit: r.querySelector('.sensor-unit').value,


### PR DESCRIPTION
## Summary
- add INFLUX_TOKEN to config endpoints
- allow editing InfluxDB token in settings UI
- include token in history queries via Authorization header

## Testing
- `npm test` *(fails: Could not read package.json)*
- `php -l get_config.php`
- `php -l save_config.php`


------
https://chatgpt.com/codex/tasks/task_e_68b40f4f84c8832ea5d30c8f3a9c1391