### PR TITLE
Use POST for InfluxDB queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 
 - Sensors may specify InfluxDB `influxMeasurement` and `influxField` values in settings to enable historical data charts. When present, the sensor card displays a history icon linking to `history.html`.
 - Global InfluxDB connection settings (host, organization, bucket) are editable in settings and returned via `get_config.php`.
+- InfluxDB queries must use `POST` requests to `/api/v2/query` with `Content-Type: application/vnd.flux` and `Accept: application/csv` headers.
 
 - When all sensors indicate green, the sensors card shows a green border.
 

--- a/history.html
+++ b/history.html
@@ -77,21 +77,28 @@
         week: { start: '-7d', window: '2h' }
       };
 
+      async function queryInflux(flux) {
+        const url = `${influxHost.replace(/\/$/, '')}/api/v2/query?org=${encodeURIComponent(influxOrg)}`;
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/vnd.flux',
+            'Accept': 'application/csv',
+            'Authorization': `Token ${influxToken}`
+          },
+          body: flux
+        });
+        if (!res.ok) {
+          throw new Error(`Influx query failed: ${res.status} ${res.statusText}`);
+        }
+        return res.text();
+      }
+
       async function fetchData(rangeKey) {
         const { start, window } = ranges[rangeKey];
         const flux = `from(bucket: "${influxBucket}")\n  |> range(start: ${start})\n  |> filter(fn: (r) => r["_measurement"] == "${sensor.influxMeasurement}")\n  |> filter(fn: (r) => r["_field"] == "${sensor.influxField}")\n  |> aggregateWindow(every: ${window}, fn: mean, createEmpty: false)\n  |> yield(name: "mean")`;
         try {
-          const url = `${influxHost.replace(/\/$/, '')}/api/v2/query?org=${encodeURIComponent(influxOrg)}`;
-          const res = await fetch(url, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/vnd.flux',
-              'Accept': 'application/csv',
-              'Authorization': `Token ${influxToken}`
-            },
-            body: flux
-          });
-          const text = await res.text();
+          const text = await queryInflux(flux);
           const lines = text.trim().split('\n').filter(line => !line.startsWith('#'));
           if (lines.length < 2) return;
           const headers = lines[0].split(',');


### PR DESCRIPTION
## Summary
- refactor history page to send Flux queries with POST
- document POST requirement for InfluxDB queries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4112a9950832e8fedda7dbe4bf5c8