### PR TITLE
Improve mobile responsiveness for dashboard and history charts

### DIFF
--- a/history.html
+++ b/history.html
@@ -2,12 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sensor History</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://code.highcharts.com/highcharts.js"></script>
 </head>
-<body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 flex dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100">
-  <aside class="w-64 bg-gray-900 text-white flex-shrink-0 flex flex-col min-h-screen sticky top-0">
+<body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 md:flex dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100">
+  <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden md:hidden"></div>
+  <aside id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-gray-900 text-white transform -translate-x-full md:translate-x-0 md:relative md:flex-shrink-0 flex flex-col transition-transform duration-200 z-40">
     <div class="p-4 text-lg font-bold flex items-center"><a href="/" class="mr-2">🔭</a>Observatory Control Panel</div>
     <nav class="px-2 flex-1">
       <ul class="space-y-2">
@@ -27,19 +29,39 @@
       </button>
     </div>
   </aside>
-  <main class="flex-1 p-6 h-full">
-    <div class="bg-white dark:bg-gray-700 dark:text-gray-200 p-6 rounded shadow w-full h-full flex flex-col">
-      <h1 id="sensorTitle" class="text-xl mb-4 text-gray-900 dark:text-gray-100">Sensor History</h1>
-      <div class="mb-4 space-x-2">
-        <button data-range="tonight" class="range-btn bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">Tonight</button>
-        <button data-range="yesterday" class="range-btn bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">Yesterday</button>
-        <button data-range="week" class="range-btn bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">This Week</button>
+  <div class="flex flex-col min-h-screen flex-1">
+    <header class="md:hidden bg-gray-900 text-white p-4 flex items-center justify-between">
+      <div class="text-lg font-bold flex items-center"><a href="/" class="mr-2">🔭</a>Observatory Control Panel</div>
+      <button id="menuButton" class="focus:outline-none">
+        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
+      </button>
+    </header>
+    <main class="flex-1 p-4 md:p-6 h-full">
+      <div class="bg-white dark:bg-gray-700 dark:text-gray-200 p-6 rounded shadow w-full h-full flex flex-col">
+        <h1 id="sensorTitle" class="text-xl mb-4 text-gray-900 dark:text-gray-100">Sensor History</h1>
+        <div class="mb-4 space-x-2">
+          <button data-range="tonight" class="range-btn bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">Tonight</button>
+          <button data-range="yesterday" class="range-btn bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">Yesterday</button>
+          <button data-range="week" class="range-btn bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">This Week</button>
+        </div>
+        <div id="historyChart" class="flex-1 min-h-[16rem]"></div>
       </div>
-      <div id="historyChart" class="flex-1"></div>
-    </div>
-  </main>
+    </main>
+  </div>
   <script type="module">
     import { loadConfig } from './js/mqttConfig.js';
+
+    const menuButton = document.getElementById('menuButton');
+    const sidebar = document.getElementById('sidebar');
+    const overlay = document.getElementById('overlay');
+    if (menuButton && sidebar && overlay) {
+      const toggleSidebar = () => {
+        sidebar.classList.toggle('-translate-x-full');
+        overlay.classList.toggle('hidden');
+      };
+      menuButton.addEventListener('click', toggleSidebar);
+      overlay.addEventListener('click', toggleSidebar);
+    }
 
     const params = new URLSearchParams(window.location.search);
     const sensorPath = params.get('sensor');

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
       <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" /></svg>
     </button>
   </header>
-  <main class="flex-1 p-6 space-y-8">
+  <main class="flex-1 p-4 md:p-6 space-y-8">
   <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">Dashboard</h1>
 
   <!-- Sensors -->
@@ -66,7 +66,7 @@
   <!-- Graphs -->
   <section class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
     <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Graphs</h2>
-    <div id="lineChart" class="h-96"></div>
+    <div id="lineChart" class="h-64 md:h-96"></div>
     <div class="flex items-center mt-2 text-xs text-gray-600 dark:text-gray-400">
       <span class="w-4 border-t-2 border-gray-400 border-dotted mr-2"></span>
       <span>Dotted segments indicate values outside the green threshold</span>


### PR DESCRIPTION
## Summary
- Adjust dashboard padding and chart height for smaller screens
- Add viewport meta, collapsible sidebar, and mobile header to history page
- Ensure history chart has minimum height on mobile

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b42113e4e0832ea6516c8a1af398d2