### PR TITLE
Show sensor units on charts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@
 - Sensors now allow selecting if green status triggers when the value is above or below the threshold via a dropdown in settings.
 - Graphs use a single Highcharts line chart with one series per sensor instead of individual bullet charts.
 - Line chart gives each sensor its own Y axis and uses dotted segments when values fall outside the green threshold.
+- Line charts display each sensor's unit in Y-axis titles and tooltips.
 
 - Use `js/mqttClient.js` for all MQTT connections instead of direct library calls.
 - Highcharts solid gauges require `highcharts-more.js` and are placed inside Tailwind card wrappers.

--- a/history.html
+++ b/history.html
@@ -133,7 +133,8 @@
           Highcharts.chart('historyChart', {
             title: { text: null },
             xAxis: { type: 'datetime' },
-            series: [{ name: sensor.name, data }],
+            yAxis: { title: { text: sensor.unit || null } },
+            series: [{ name: sensor.name, data, tooltip: { valueSuffix: sensor.unit ? ` ${sensor.unit}` : '' } }],
             legend: { enabled: false }
           });
         } catch (err) {

--- a/index.html
+++ b/index.html
@@ -308,7 +308,7 @@ setToggleDisabled(true);
 
 function initLineChart() {
   const yAxis = sensors.map((s, idx) => ({
-    title: { text: s.name },
+    title: { text: s.unit ? `${s.name} (${s.unit})` : s.name },
     opposite: idx % 2 === 1
   }));
   const series = sensors.map((s, idx) => {
@@ -319,7 +319,7 @@ function initLineChart() {
         ? [{ value: green, dashStyle: 'Dot' }, {}]
         : [{ value: green }, { dashStyle: 'Dot' }];
     }
-    return { name: s.name, data: [], yAxis: idx, zones };
+    return { name: s.name, data: [], yAxis: idx, zones, tooltip: { valueSuffix: s.unit ? ` ${s.unit}` : '' } };
   });
   lineChart = Highcharts.chart('lineChart', {
     chart: { type: 'line' },


### PR DESCRIPTION
## Summary
- Label each dashboard chart axis with the sensor's unit and include the unit in tooltip values
- Add unit titles and tooltip suffixes to the history chart
- Document chart unit convention in AGENTS.md

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b422f2016c832ebee3fbc63e1f7142