### PR TITLE
Ensure graph text is black in light mode

### DIFF
--- a/history.html
+++ b/history.html
@@ -77,26 +77,26 @@
       Highcharts.setOptions({
         chart: {
           backgroundColor: 'transparent',
-          style: { color: isDark ? '#f3f4f6' : '#1f2937' }
+          style: { color: isDark ? '#f3f4f6' : '#000000' }
         },
-        title: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+        title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
         xAxis: {
-          labels: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+          labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
           gridLineColor: isDark ? '#374151' : '#e5e7eb',
           lineColor: isDark ? '#374151' : '#e5e7eb',
           tickColor: isDark ? '#374151' : '#e5e7eb'
         },
         yAxis: {
-          labels: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
-          title: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+          labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
+          title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
           gridLineColor: isDark ? '#374151' : '#e5e7eb',
           lineColor: isDark ? '#374151' : '#e5e7eb',
           tickColor: isDark ? '#374151' : '#e5e7eb'
         },
-        legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+        legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#000000' } },
         tooltip: {
           backgroundColor: isDark ? '#1f2937' : '#ffffff',
-          style: { color: isDark ? '#f3f4f6' : '#1f2937' }
+          style: { color: isDark ? '#f3f4f6' : '#000000' }
         }
       });
     }

--- a/index.html
+++ b/index.html
@@ -96,26 +96,26 @@ function applyChartTheme(isDark) {
   Highcharts.setOptions({
     chart: {
       backgroundColor: 'transparent',
-      style: { color: isDark ? '#f3f4f6' : '#1f2937' }
+      style: { color: isDark ? '#f3f4f6' : '#000000' }
     },
-    title: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+    title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
     xAxis: {
-      labels: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+      labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
       gridLineColor: isDark ? '#374151' : '#e5e7eb',
       lineColor: isDark ? '#374151' : '#e5e7eb',
       tickColor: isDark ? '#374151' : '#e5e7eb'
     },
     yAxis: {
-      labels: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
-      title: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+      labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
+      title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
       gridLineColor: isDark ? '#374151' : '#e5e7eb',
       lineColor: isDark ? '#374151' : '#e5e7eb',
       tickColor: isDark ? '#374151' : '#e5e7eb'
     },
-    legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+    legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#000000' } },
     tooltip: {
       backgroundColor: isDark ? '#1f2937' : '#ffffff',
-      style: { color: isDark ? '#f3f4f6' : '#1f2937' }
+      style: { color: isDark ? '#f3f4f6' : '#000000' }
     }
   });
 }


### PR DESCRIPTION
## Summary
- Force Highcharts graph text to render in pure black when light theme is active
- Apply consistent black text styling to dashboard and history charts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b34dcec0832e8c64aa1854493d11