### PR TITLE
Ensure graph text is black in light mode

### DIFF
--- a/history.html
+++ b/history.html
@@ -7,7 +7,6 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <script src="https://code.highcharts.com/highcharts.js"></script>
-  <script src="https://code.highcharts.com/themes/adaptive.js"></script>
 </head>
 <body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 md:flex dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100">
   <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden md:hidden"></div>
@@ -77,26 +76,26 @@
       Highcharts.setOptions({
         chart: {
           backgroundColor: 'transparent',
-          style: { color: isDark ? '#f3f4f6' : '#1f2937' }
+          style: { color: isDark ? '#f3f4f6' : '#000000' }
         },
-        title: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+        title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
         xAxis: {
-          labels: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+          labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
           gridLineColor: isDark ? '#374151' : '#e5e7eb',
           lineColor: isDark ? '#374151' : '#e5e7eb',
           tickColor: isDark ? '#374151' : '#e5e7eb'
         },
         yAxis: {
-          labels: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
-          title: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+          labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
+          title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
           gridLineColor: isDark ? '#374151' : '#e5e7eb',
           lineColor: isDark ? '#374151' : '#e5e7eb',
           tickColor: isDark ? '#374151' : '#e5e7eb'
         },
-        legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+        legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#000000' } },
         tooltip: {
           backgroundColor: isDark ? '#1f2937' : '#ffffff',
-          style: { color: isDark ? '#f3f4f6' : '#1f2937' }
+          style: { color: isDark ? '#f3f4f6' : '#000000' }
         }
       });
     }

--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
 <script src="https://unpkg.com/mqtt/dist/mqtt.min.js"></script>
 <script src="js/mqttClient.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
-<script src="https://code.highcharts.com/themes/adaptive.js"></script>
 </head>
 <body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 md:flex dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100">
 <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden md:hidden"></div>
@@ -96,26 +95,26 @@ function applyChartTheme(isDark) {
   Highcharts.setOptions({
     chart: {
       backgroundColor: 'transparent',
-      style: { color: isDark ? '#f3f4f6' : '#1f2937' }
+      style: { color: isDark ? '#f3f4f6' : '#000000' }
     },
-    title: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+    title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
     xAxis: {
-      labels: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+      labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
       gridLineColor: isDark ? '#374151' : '#e5e7eb',
       lineColor: isDark ? '#374151' : '#e5e7eb',
       tickColor: isDark ? '#374151' : '#e5e7eb'
     },
     yAxis: {
-      labels: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
-      title: { style: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+      labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
+      title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
       gridLineColor: isDark ? '#374151' : '#e5e7eb',
       lineColor: isDark ? '#374151' : '#e5e7eb',
       tickColor: isDark ? '#374151' : '#e5e7eb'
     },
-    legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#1f2937' } },
+    legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#000000' } },
     tooltip: {
       backgroundColor: isDark ? '#1f2937' : '#ffffff',
-      style: { color: isDark ? '#f3f4f6' : '#1f2937' }
+      style: { color: isDark ? '#f3f4f6' : '#000000' }
     }
   });
 }


### PR DESCRIPTION
## Summary
- Remove Highcharts adaptive theme so custom light-mode styling can apply
- Keep charts' text styling consistent between index and history pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b34dcec0832e8c64aa1854493d11