### PR TITLE
Add theme selector with light, dark, and system modes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,5 +49,5 @@
 - Configuration endpoints respond with JSON and proper `Content-Type` headers; client pages should surface server error messages.
 - Database migrations should verify column existence using `PRAGMA table_info` before attempting schema alterations.
 
-- Dark mode is toggled via a sidebar switch storing preference in `localStorage` and applying Tailwind `dark:` classes on the `<html>` element.
+- Sidebar includes a theme selector (Light/Dark/System) storing preference in `localStorage`. The `dark` class on `<html>` follows the selected theme, with `System` using `prefers-color-scheme`.
 - Interactive elements like buttons and form inputs should provide matching `dark:` variants for colors and borders.

--- a/history.html
+++ b/history.html
@@ -24,10 +24,12 @@
       </ul>
     </nav>
     <div class="p-4 flex items-center justify-between">
-      <span class="text-sm">Dark Mode</span>
-      <button id="darkModeToggle" class="relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200 dark:bg-gray-600">
-        <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-      </button>
+      <label for="themeSelect" class="text-sm">Theme</label>
+      <select id="themeSelect" class="bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 rounded p-1">
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="system">System</option>
+      </select>
     </div>
   </aside>
   <div class="flex flex-col min-h-screen flex-1">
@@ -70,7 +72,7 @@
     let historyChart;
     let currentRange = 'tonight';
 
-    const darkModeToggle = document.getElementById('darkModeToggle');
+    const themeSelect = document.getElementById('themeSelect');
 
     function applyChartTheme(isDark) {
       Highcharts.setOptions({
@@ -100,26 +102,31 @@
       });
     }
 
-    if (darkModeToggle) {
-      const storedTheme = localStorage.getItem('theme');
-      const hour = new Date().getHours();
-      const isDark = storedTheme ? storedTheme === 'dark' : (hour >= 18 || hour < 6);
-      if (isDark) {
-        document.documentElement.classList.add('dark');
-        darkModeToggle.classList.remove('bg-gray-200');
-        darkModeToggle.classList.add('bg-green-500');
-        darkModeToggle.querySelector('span')?.classList.add('translate-x-5');
-      }
-      applyChartTheme(isDark);
-      darkModeToggle.addEventListener('click', () => {
-        const enabled = document.documentElement.classList.toggle('dark');
-        darkModeToggle.classList.toggle('bg-green-500', enabled);
-        darkModeToggle.classList.toggle('bg-gray-200', !enabled);
-        darkModeToggle.querySelector('span')?.classList.toggle('translate-x-5');
-        localStorage.setItem('theme', enabled ? 'dark' : 'light');
-        applyChartTheme(enabled);
+    if (themeSelect) {
+      const storedTheme = localStorage.getItem('theme') || 'system';
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+      function setTheme(theme) {
+        const isDark = theme === 'dark' || (theme === 'system' && mediaQuery.matches);
+        document.documentElement.classList.toggle('dark', isDark);
+        applyChartTheme(isDark);
         if (historyChart) {
           fetchData(currentRange);
+        }
+      }
+
+      themeSelect.value = storedTheme;
+      setTheme(storedTheme);
+
+      themeSelect.addEventListener('change', e => {
+        const value = e.target.value;
+        localStorage.setItem('theme', value);
+        setTheme(value);
+      });
+
+      mediaQuery.addEventListener('change', () => {
+        if (localStorage.getItem('theme') === 'system') {
+          setTheme('system');
         }
       });
     } else {

--- a/index.html
+++ b/index.html
@@ -26,10 +26,12 @@
     </ul>
   </nav>
   <div class="p-4 flex items-center justify-between">
-    <span class="text-sm">Dark Mode</span>
-    <button id="darkModeToggle" class="relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200 dark:bg-gray-600">
-      <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-    </button>
+    <label for="themeSelect" class="text-sm">Theme</label>
+    <select id="themeSelect" class="bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 rounded p-1">
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+      <option value="system">System</option>
+    </select>
   </div>
   <div id="connectionStatus" class="p-4 text-sm flex items-center text-gray-300 dark:text-gray-400">
     <span id="statusDot" class="h-2 w-2 rounded-full bg-yellow-500 mr-2"></span>
@@ -89,7 +91,7 @@ import { loadConfig } from './js/mqttConfig.js';
 const menuButton = document.getElementById('menuButton');
 const sidebar = document.getElementById('sidebar');
 const overlay = document.getElementById('overlay');
-const darkModeToggle = document.getElementById('darkModeToggle');
+const themeSelect = document.getElementById('themeSelect');
 
 function applyChartTheme(isDark) {
   Highcharts.setOptions({
@@ -127,27 +129,36 @@ if (menuButton && sidebar && overlay) {
   overlay.addEventListener('click', toggleSidebar);
 }
 
-if (darkModeToggle) {
-  const storedTheme = localStorage.getItem('theme');
-  const hour = new Date().getHours();
-  const isDark = storedTheme ? storedTheme === 'dark' : (hour >= 18 || hour < 6);
-  if (isDark) {
-    document.documentElement.classList.add('dark');
-    darkModeToggle.classList.remove('bg-gray-200');
-    darkModeToggle.classList.add('bg-green-500');
-    darkModeToggle.querySelector('span')?.classList.add('translate-x-5');
+if (themeSelect) {
+  const storedTheme = localStorage.getItem('theme') || 'system';
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+  function setTheme(theme) {
+    const isDark = theme === 'dark' || (theme === 'system' && mediaQuery.matches);
+    document.documentElement.classList.toggle('dark', isDark);
+    applyChartTheme(isDark);
   }
-  applyChartTheme(isDark);
-  darkModeToggle.addEventListener('click', () => {
-    const enabled = document.documentElement.classList.toggle('dark');
-    darkModeToggle.classList.toggle('bg-green-500', enabled);
-    darkModeToggle.classList.toggle('bg-gray-200', !enabled);
-    darkModeToggle.querySelector('span')?.classList.toggle('translate-x-5');
-    localStorage.setItem('theme', enabled ? 'dark' : 'light');
-    applyChartTheme(enabled);
+
+  themeSelect.value = storedTheme;
+  setTheme(storedTheme);
+
+  themeSelect.addEventListener('change', e => {
+    const value = e.target.value;
+    localStorage.setItem('theme', value);
+    setTheme(value);
     if (lineChart) {
       lineChart.destroy();
       initLineChart();
+    }
+  });
+
+  mediaQuery.addEventListener('change', () => {
+    if (localStorage.getItem('theme') === 'system') {
+      setTheme('system');
+      if (lineChart) {
+        lineChart.destroy();
+        initLineChart();
+      }
     }
   });
 } else {

--- a/settings.html
+++ b/settings.html
@@ -21,10 +21,12 @@
       </ul>
     </nav>
     <div class="p-4 flex items-center justify-between">
-      <span class="text-sm">Dark Mode</span>
-      <button id="darkModeToggle" class="relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200 dark:bg-gray-600">
-        <span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span>
-      </button>
+      <label for="themeSelect" class="text-sm">Theme</label>
+      <select id="themeSelect" class="bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 rounded p-1">
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="system">System</option>
+      </select>
     </div>
   </aside>
   <main class="flex-1 p-6">
@@ -121,21 +123,29 @@
   <script type="module">
     import { loadConfig } from './js/mqttConfig.js';
 
-    const darkModeToggle = document.getElementById('darkModeToggle');
-    if (darkModeToggle) {
-      const isDark = localStorage.getItem('theme') === 'dark';
-      if (isDark) {
-        document.documentElement.classList.add('dark');
-        darkModeToggle.classList.remove('bg-gray-200');
-        darkModeToggle.classList.add('bg-green-500');
-        darkModeToggle.querySelector('span')?.classList.add('translate-x-5');
+    const themeSelect = document.getElementById('themeSelect');
+    if (themeSelect) {
+      const storedTheme = localStorage.getItem('theme') || 'system';
+      const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+      function setTheme(theme) {
+        const isDark = theme === 'dark' || (theme === 'system' && mediaQuery.matches);
+        document.documentElement.classList.toggle('dark', isDark);
       }
-      darkModeToggle.addEventListener('click', () => {
-        const enabled = document.documentElement.classList.toggle('dark');
-        darkModeToggle.classList.toggle('bg-green-500', enabled);
-        darkModeToggle.classList.toggle('bg-gray-200', !enabled);
-        darkModeToggle.querySelector('span')?.classList.toggle('translate-x-5');
-        localStorage.setItem('theme', enabled ? 'dark' : 'light');
+
+      themeSelect.value = storedTheme;
+      setTheme(storedTheme);
+
+      themeSelect.addEventListener('change', e => {
+        const value = e.target.value;
+        localStorage.setItem('theme', value);
+        setTheme(value);
+      });
+
+      mediaQuery.addEventListener('change', () => {
+        if (localStorage.getItem('theme') === 'system') {
+          setTheme('system');
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- Replace sidebar dark-mode toggle with a theme selector supporting Light, Dark, and System options
- Store theme preference in localStorage and update Highcharts theme & pages accordingly
- Document theme selector behavior in AGENTS guidelines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d8dc98bc832e8f94ff2754196ea7