### PR TITLE
Refresh observatory UI styling

### DIFF
--- a/history.html
+++ b/history.html
@@ -4,59 +4,115 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Sensor History</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['"Plus Jakarta Sans"', 'ui-sans-serif', 'system-ui', 'sans-serif']
+          },
+          colors: {
+            aurora: {
+              200: '#c4d9ff',
+              300: '#92b4ff',
+              400: '#5b8fff',
+              500: '#2d72ff'
+            }
+          }
+        }
+      }
+    };
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <script src="https://code.highcharts.com/highcharts.js"></script>
 </head>
-<body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 md:flex dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100">
-  <div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden md:hidden"></div>
-  <aside id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-gray-900 text-white transform -translate-x-full md:translate-x-0 md:relative md:flex-shrink-0 flex flex-col transition-transform duration-200 z-40">
-    <div class="p-4 text-lg font-bold flex items-center"><a href="/" class="mr-2"><i class="fa-solid fa-binoculars"></i></a>Observatory</div>
-    <div class="px-4 pb-4">
-      <div class="flex items-center justify-between">
-        <label for="themeSelect" class="text-sm">Theme</label>
-        <select id="themeSelect" class="bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 rounded p-1">
-          <option value="light">Light</option>
-          <option value="dark">Dark</option>
-          <option value="system">System</option>
-        </select>
-      </div>
-    </div>
-    <nav class="px-2 flex-1">
-      <ul class="space-y-2">
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://10.0.179.242" target="_blank">AAGSolo</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://data.smeird.com:3000/public-dashboards/9d4866d34e934549a20debd888358718?refresh=1m&from=now-24h&to=now&timezone=browser" target="_blank">Obs Graphs</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://data.smeird.com:3000/public-dashboards/2ed28400ef714b6899a67ca635137a59" target="_blank">Weather</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://ob.smeird.com" target="_blank">Public obs</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://www.smeird.com" target="_blank">Public Weather</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="https://clearoutside.com/forecast/51.81/-0.29" target="_blank">Night Forecast</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="settings.html">Settings</a></li>
-      </ul>
-    </nav>
-  </aside>
-  <div class="flex flex-col min-h-screen flex-1">
-    <header class="md:hidden bg-gray-900 text-white p-4 flex items-center justify-between">
-      <div class="text-lg font-bold flex items-center"><a href="/" class="mr-2"><i class="fa-solid fa-binoculars"></i></a>Observatory</div>
-      <button id="menuButton" class="focus:outline-none">
-        <i class="fa-solid fa-bars text-xl"></i>
-      </button>
-    </header>
-    <main class="flex-1 p-4 md:p-6 h-full">
-      <div class="bg-white dark:bg-gray-700 dark:text-gray-200 p-6 rounded shadow w-full h-full flex flex-col">
-        <h1 id="sensorTitle" class="text-xl mb-4 text-gray-900 dark:text-gray-100">Sensor History</h1>
-        <div class="mb-4 space-x-2">
-          <button data-range="tonight" class="range-btn bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">Tonight</button>
-          <button data-range="yesterday" class="range-btn bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">Yesterday</button>
-          <button data-range="week" class="range-btn bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">This Week</button>
-        </div>
-        <div id="historyChart" class="flex-1 min-h-[16rem]"></div>
-      </div>
-    </main>
+<body class="min-h-screen font-sans antialiased text-slate-900 dark:text-slate-100">
+  <div class="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950"></div>
+    <div class="absolute left-1/2 top-[-10%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-aurora-300/40 blur-3xl dark:bg-aurora-500/30"></div>
+    <div class="absolute bottom-[-25%] right-[-10%] h-[480px] w-[480px] rounded-full bg-aurora-200/40 blur-3xl dark:bg-aurora-400/20"></div>
+    <div class="absolute left-[-15%] top-1/3 h-72 w-72 rounded-full bg-white/40 blur-3xl dark:bg-white/5"></div>
   </div>
+  <div id="overlay" class="fixed inset-0 z-30 bg-slate-900/60 backdrop-blur-sm hidden md:hidden"></div>
+  <div class="relative z-10 min-h-screen md:flex">
+    <aside id="sidebar" class="fixed inset-y-0 left-0 z-40 flex w-72 -translate-x-full transform flex-col border-r border-white/10 bg-slate-900/80 px-6 pb-6 pt-8 text-slate-100 backdrop-blur-lg transition-transform duration-300 md:relative md:translate-x-0 md:flex-shrink-0 md:border-r md:border-slate-200/20">
+      <div class="mb-8 flex items-center justify-between">
+        <a href="/" class="flex items-center gap-3 text-lg font-semibold tracking-tight">
+          <span class="grid h-10 w-10 place-items-center rounded-2xl bg-white/10 text-aurora-200 shadow ring-1 ring-white/20"><i class="fa-solid fa-binoculars"></i></span>
+          <span class="leading-tight">Observatory</span>
+        </a>
+        <button id="closeSidebar" class="md:hidden text-slate-300 transition hover:text-white" aria-label="Close menu">
+          <i class="fa-solid fa-xmark text-xl"></i>
+        </button>
+      </div>
+      <div class="space-y-6 overflow-y-auto">
+        <div class="rounded-2xl border border-white/10 bg-white/10 p-4 shadow-inner backdrop-blur">
+          <div class="flex items-center justify-between text-xs uppercase tracking-wide text-slate-200/80">
+            <span>Theme</span>
+            <i class="fa-solid fa-circle-half-stroke text-aurora-200"></i>
+          </div>
+          <select id="themeSelect" class="mt-3 w-full rounded-xl border border-white/10 bg-slate-900/80 px-3 py-2 text-sm font-medium text-slate-100 shadow-sm outline-none transition focus:border-aurora-400 focus:ring-2 focus:ring-aurora-300/40">
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+            <option value="system">System</option>
+          </select>
+        </div>
+        <nav class="space-y-2 text-sm font-medium">
+          <p class="px-3 text-xs uppercase tracking-[0.3em] text-slate-200/60">Quick Links</p>
+          <ul class="space-y-2">
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://10.0.179.242" target="_blank"><i class="fa-solid fa-mountain-sun text-aurora-200"></i><span>AAGSolo</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://data.smeird.com:3000/public-dashboards/9d4866d34e934549a20debd888358718?refresh=1m&amp;from=now-24h&amp;to=now&amp;timezone=browser" target="_blank"><i class="fa-solid fa-chart-line text-aurora-200"></i><span>Obs Graphs</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://data.smeird.com:3000/public-dashboards/2ed28400ef714b6899a67ca635137a59" target="_blank"><i class="fa-solid fa-cloud-sun text-aurora-200"></i><span>Weather</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://ob.smeird.com" target="_blank"><i class="fa-solid fa-earth-europe text-aurora-200"></i><span>Public obs</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://www.smeird.com" target="_blank"><i class="fa-solid fa-droplet text-aurora-200"></i><span>Public Weather</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="https://clearoutside.com/forecast/51.81/-0.29" target="_blank"><i class="fa-solid fa-moon-stars text-aurora-200"></i><span>Night Forecast</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="settings.html"><i class="fa-solid fa-sliders text-aurora-200"></i><span>Settings</span></a></li>
+          </ul>
+        </nav>
+      </div>
+    </aside>
+    <div class="flex min-h-screen flex-1 flex-col">
+      <header class="flex items-center justify-between gap-4 bg-white/80 px-6 py-4 shadow-sm backdrop-blur dark:bg-slate-900/70 md:hidden">
+        <div class="flex items-center gap-3 text-base font-semibold text-slate-700 dark:text-slate-100">
+          <span class="grid h-9 w-9 place-items-center rounded-2xl bg-aurora-400/20 text-aurora-500 dark:bg-aurora-500/20"><i class="fa-solid fa-binoculars"></i></span>
+          Observatory
+        </div>
+        <button id="menuButton" class="rounded-xl border border-slate-200 bg-white/80 px-3 py-2 text-slate-700 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-100" aria-label="Open menu">
+          <i class="fa-solid fa-bars text-lg"></i>
+        </button>
+      </header>
+      <main class="flex-1 px-4 py-10 sm:px-8">
+        <div class="mx-auto flex w-full max-w-6xl flex-col gap-8">
+          <div class="flex flex-col gap-3">
+            <p class="text-sm uppercase tracking-[0.35em] text-slate-500/70 dark:text-slate-300/60">History</p>
+            <h1 class="text-4xl font-semibold tracking-tight text-slate-900 dark:text-white"><span class="bg-gradient-to-r from-aurora-400 via-blue-500 to-purple-500 bg-clip-text text-transparent">Sensor History</span></h1>
+            <p class="max-w-3xl text-sm text-slate-600 dark:text-slate-300/80">Explore historical performance and threshold compliance using the interactive range filters below.</p>
+          </div>
+          <div class="rounded-3xl border border-slate-200/60 bg-white/80 p-8 shadow-xl backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
+            <div class="flex flex-wrap items-center justify-between gap-4">
+              <h2 id="sensorTitle" class="text-2xl font-semibold text-slate-900 dark:text-white">Sensor History</h2>
+              <div class="flex flex-wrap gap-2">
+                <button data-range="tonight" class="range-btn inline-flex items-center gap-2 rounded-xl border border-aurora-300/40 bg-aurora-300/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-aurora-600 transition hover:-translate-y-0.5 hover:bg-aurora-300/30 dark:border-aurora-500/30 dark:bg-aurora-500/10 dark:text-aurora-200"><i class="fa-solid fa-moon"></i> Tonight</button>
+                <button data-range="yesterday" class="range-btn inline-flex items-center gap-2 rounded-xl border border-slate-200/70 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600 transition hover:-translate-y-0.5 hover:border-aurora-300/40 hover:bg-aurora-300/20 hover:text-aurora-600 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-aurora-500/40 dark:hover:bg-aurora-500/10 dark:hover:text-aurora-200"><i class="fa-solid fa-calendar-day"></i> Yesterday</button>
+                <button data-range="week" class="range-btn inline-flex items-center gap-2 rounded-xl border border-slate-200/70 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600 transition hover:-translate-y-0.5 hover:border-aurora-300/40 hover:bg-aurora-300/20 hover:text-aurora-600 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-aurora-500/40 dark:hover:bg-aurora-500/10 dark:hover:text-aurora-200"><i class="fa-solid fa-calendar-week"></i> This Week</button>
+              </div>
+            </div>
+            <div id="historyChart" class="mt-6 min-h-[18rem] rounded-2xl border border-slate-200/60 bg-slate-900/5 dark:border-white/10 dark:bg-black/20"></div>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+
   <script type="module">
     import { loadConfig } from './js/mqttConfig.js';
 
     const menuButton = document.getElementById('menuButton');
+    const closeSidebar = document.getElementById('closeSidebar');
     const sidebar = document.getElementById('sidebar');
     const overlay = document.getElementById('overlay');
     if (menuButton && sidebar && overlay) {
@@ -66,6 +122,9 @@
       };
       menuButton.addEventListener('click', toggleSidebar);
       overlay.addEventListener('click', toggleSidebar);
+      if (closeSidebar) {
+        closeSidebar.addEventListener('click', toggleSidebar);
+      }
     }
 
     const params = new URLSearchParams(window.location.search);
@@ -80,26 +139,27 @@
       Highcharts.setOptions({
         chart: {
           backgroundColor: 'transparent',
-          style: { color: isDark ? '#f3f4f6' : '#000000' }
+          style: { color: isDark ? '#f3f4f6' : '#0f172a' }
         },
-        title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
+        title: { style: { color: isDark ? '#f3f4f6' : '#0f172a' } },
         xAxis: {
-          labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
-          gridLineColor: isDark ? '#374151' : '#e5e7eb',
-          lineColor: isDark ? '#374151' : '#e5e7eb',
-          tickColor: isDark ? '#374151' : '#e5e7eb'
+          labels: { style: { color: isDark ? '#e2e8f0' : '#0f172a' } },
+          gridLineColor: isDark ? '#1f2937' : '#e2e8f0',
+          lineColor: isDark ? '#334155' : '#cbd5f5',
+          tickColor: isDark ? '#334155' : '#94a3b8'
         },
         yAxis: {
-          labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
-          title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
-          gridLineColor: isDark ? '#374151' : '#e5e7eb',
-          lineColor: isDark ? '#374151' : '#e5e7eb',
-          tickColor: isDark ? '#374151' : '#e5e7eb'
+          labels: { style: { color: isDark ? '#e2e8f0' : '#0f172a' } },
+          title: { style: { color: isDark ? '#e2e8f0' : '#0f172a' } },
+          gridLineColor: isDark ? '#1f2937' : '#e2e8f0',
+          lineColor: isDark ? '#334155' : '#cbd5f5',
+          tickColor: isDark ? '#334155' : '#94a3b8'
         },
-        legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#000000' } },
+        legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#0f172a' } },
         tooltip: {
-          backgroundColor: isDark ? '#1f2937' : '#ffffff',
-          style: { color: isDark ? '#f3f4f6' : '#000000' }
+          backgroundColor: isDark ? '#111827' : '#ffffff',
+          borderColor: isDark ? '#1d4ed8' : '#dbeafe',
+          style: { color: isDark ? '#f3f4f6' : '#0f172a' }
         }
       });
     }
@@ -169,6 +229,13 @@
 
       async function fetchData(rangeKey) {
         currentRange = rangeKey;
+        document.querySelectorAll('.range-btn').forEach(btn => {
+          if (btn.dataset.range === rangeKey) {
+            btn.classList.add('border-aurora-300/40', 'bg-aurora-300/30', 'text-aurora-600', 'dark:border-aurora-500/40', 'dark:bg-aurora-500/20', 'dark:text-aurora-200');
+          } else {
+            btn.classList.remove('border-aurora-300/40', 'bg-aurora-300/30', 'text-aurora-600', 'dark:border-aurora-500/40', 'dark:bg-aurora-500/20', 'dark:text-aurora-200');
+          }
+        });
         const { start, window } = ranges[rangeKey];
         const flux = `from(bucket: "${influxBucket}")\n  |> range(start: ${start})\n  |> filter(fn: (r) => r["_measurement"] == "${sensor.influxMeasurement}")\n  |> filter(fn: (r) => r["_field"] == "${sensor.influxField}")\n  |> aggregateWindow(every: ${window}, fn: mean, createEmpty: false)\n  |> yield(name: "mean")`;
         try {

--- a/index.html
+++ b/index.html
@@ -4,93 +4,150 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Observatory</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script>
+  tailwind.config = {
+    theme: {
+      extend: {
+        fontFamily: {
+          sans: ['"Plus Jakarta Sans"', 'ui-sans-serif', 'system-ui', 'sans-serif']
+        },
+        colors: {
+          aurora: {
+            200: '#c4d9ff',
+            300: '#92b4ff',
+            400: '#5b8fff',
+            500: '#2d72ff'
+          }
+        }
+      }
+    }
+  };
+</script>
 <script src="https://cdn.tailwindcss.com"></script>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <script src="https://unpkg.com/mqtt/dist/mqtt.min.js"></script>
 <script src="js/mqttClient.js"></script>
 <script src="https://code.highcharts.com/highcharts.js"></script>
 </head>
-<body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 md:flex dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100">
-<div id="overlay" class="fixed inset-0 bg-black bg-opacity-50 hidden md:hidden"></div>
-<aside id="sidebar" class="fixed inset-y-0 left-0 w-64 bg-gray-900 text-white transform -translate-x-full md:translate-x-0 md:relative md:flex-shrink-0 flex flex-col transition-transform duration-200 z-40">
-  <div class="p-4 text-lg font-bold flex items-center"><a href="/" class="mr-2"><i class="fa-solid fa-binoculars"></i></a>Observatory</div>
-  <div class="px-4 pb-4 space-y-4">
-    <div id="connectionStatus" class="text-sm flex items-center text-gray-300 dark:text-gray-400">
-      <span id="statusDot" class="h-2 w-2 rounded-full bg-yellow-500 mr-2"></span>
-      <span id="statusText">Connecting...</span>
+<body class="min-h-screen font-sans antialiased text-slate-900 dark:text-slate-100">
+<div class="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+  <div class="absolute inset-0 bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950"></div>
+  <div class="absolute left-1/2 top-[-10%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-aurora-300/40 blur-3xl dark:bg-aurora-500/30"></div>
+  <div class="absolute bottom-[-25%] right-[-10%] h-[480px] w-[480px] rounded-full bg-aurora-200/40 blur-3xl dark:bg-aurora-400/20"></div>
+  <div class="absolute left-[-15%] top-1/3 h-72 w-72 rounded-full bg-white/40 blur-3xl dark:bg-white/5"></div>
+</div>
+<div id="overlay" class="fixed inset-0 z-30 bg-slate-900/60 backdrop-blur-sm hidden md:hidden"></div>
+<div class="relative z-10 min-h-screen md:flex">
+  <aside id="sidebar" class="fixed inset-y-0 left-0 z-40 flex w-72 -translate-x-full transform flex-col border-r border-white/10 bg-slate-900/80 px-6 pb-6 pt-8 text-slate-100 backdrop-blur-lg transition-transform duration-300 md:relative md:translate-x-0 md:flex-shrink-0 md:border-r md:border-slate-200/20">
+    <div class="mb-8 flex items-center justify-between">
+      <a href="/" class="flex items-center gap-3 text-lg font-semibold tracking-tight">
+        <span class="grid h-10 w-10 place-items-center rounded-2xl bg-white/10 text-aurora-200 shadow ring-1 ring-white/20"><i class="fa-solid fa-binoculars"></i></span>
+        <span class="leading-tight">Observatory</span>
+      </a>
+      <button id="closeSidebar" class="md:hidden text-slate-300 transition hover:text-white" aria-label="Close menu">
+        <i class="fa-solid fa-xmark text-xl"></i>
+      </button>
     </div>
-    <div class="flex items-center justify-between">
-      <label for="themeSelect" class="text-sm">Theme</label>
-      <select id="themeSelect" class="bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 rounded p-1">
-        <option value="light">Light</option>
-        <option value="dark">Dark</option>
-        <option value="system">System</option>
-      </select>
+    <div class="space-y-6 overflow-y-auto">
+      <div class="rounded-2xl border border-white/10 bg-white/10 p-4 shadow-inner backdrop-blur">
+        <div class="flex items-center justify-between text-xs uppercase tracking-wide text-slate-200/80">
+          <span>Theme</span>
+          <i class="fa-solid fa-circle-half-stroke text-aurora-200"></i>
+        </div>
+        <select id="themeSelect" class="mt-3 w-full rounded-xl border border-white/10 bg-slate-900/80 px-3 py-2 text-sm font-medium text-slate-100 shadow-sm outline-none transition focus:border-aurora-400 focus:ring-2 focus:ring-aurora-300/40">
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          <option value="system">System</option>
+        </select>
+      </div>
+      <nav class="space-y-2 text-sm font-medium">
+        <p class="px-3 text-xs uppercase tracking-[0.3em] text-slate-200/60">Quick Links</p>
+        <ul class="space-y-2">
+          <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://10.0.179.242" target="_blank"><i class="fa-solid fa-mountain-sun text-aurora-200"></i><span>AAGSolo</span></a></li>
+          <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://data.smeird.com:3000/public-dashboards/9d4866d34e934549a20debd888358718?refresh=1m&amp;from=now-24h&amp;to=now&amp;timezone=browser" target="_blank"><i class="fa-solid fa-chart-line text-aurora-200"></i><span>Obs Graphs</span></a></li>
+          <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://data.smeird.com:3000/public-dashboards/2ed28400ef714b6899a67ca635137a59" target="_blank"><i class="fa-solid fa-cloud-sun text-aurora-200"></i><span>Weather</span></a></li>
+          <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://ob.smeird.com" target="_blank"><i class="fa-solid fa-earth-europe text-aurora-200"></i><span>Public obs</span></a></li>
+          <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://www.smeird.com" target="_blank"><i class="fa-solid fa-droplet text-aurora-200"></i><span>Public Weather</span></a></li>
+          <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="https://clearoutside.com/forecast/51.81/-0.29" target="_blank"><i class="fa-solid fa-moon-stars text-aurora-200"></i><span>Night Forecast</span></a></li>
+          <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="settings.html"><i class="fa-solid fa-sliders text-aurora-200"></i><span>Settings</span></a></li>
+        </ul>
+      </nav>
     </div>
+    <div class="mt-auto rounded-2xl border border-white/10 bg-white/5 p-4 shadow-inner backdrop-blur">
+      <p class="text-xs uppercase tracking-[0.3em] text-slate-200/60">Connection</p>
+      <div id="connectionStatus" class="mt-3 flex items-center text-sm text-slate-200/80">
+        <span id="statusDot" class="mr-3 h-2.5 w-2.5 rounded-full bg-yellow-400 shadow-[0_0_0_4px_rgba(255,255,255,0.12)]"></span>
+        <span id="statusText">Connecting...</span>
+      </div>
+    </div>
+  </aside>
+  <div class="flex min-h-screen flex-1 flex-col">
+    <header class="flex items-center justify-between gap-4 bg-white/80 px-6 py-4 shadow-sm backdrop-blur dark:bg-slate-900/70 md:hidden">
+      <div class="flex items-center gap-3 text-base font-semibold text-slate-700 dark:text-slate-100">
+        <span class="grid h-9 w-9 place-items-center rounded-2xl bg-aurora-400/20 text-aurora-500 dark:bg-aurora-500/20"><i class="fa-solid fa-binoculars"></i></span>
+        Observatory
+      </div>
+      <button id="menuButton" class="rounded-xl border border-slate-200 bg-white/80 px-3 py-2 text-slate-700 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-100" aria-label="Open menu">
+        <i class="fa-solid fa-bars text-lg"></i>
+      </button>
+    </header>
+    <main class="flex-1 px-4 py-10 sm:px-8">
+      <div class="mx-auto flex w-full max-w-7xl flex-col gap-10">
+        <div class="flex flex-col gap-3">
+          <p class="text-sm uppercase tracking-[0.35em] text-slate-500/70 dark:text-slate-300/60">Live Control</p>
+          <h1 class="text-4xl font-semibold tracking-tight text-slate-900 dark:text-white"><span class="bg-gradient-to-r from-aurora-400 via-blue-500 to-purple-500 bg-clip-text text-transparent">Dashboard</span></h1>
+          <p class="max-w-3xl text-sm text-slate-600 dark:text-slate-300/80">Monitor sensor health, operate the roof and switches, and watch the skycam feed in a refreshed interface that keeps everything within easy reach.</p>
+        </div>
+        <section id="sensorCard" class="rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-xl backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">Sensors</h2>
+            <div class="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400"><span class="h-2.5 w-2.5 rounded-full bg-emerald-400"></span>Optimal</div>
+          </div>
+          <div id="sensorsContainer" class="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-3"></div>
+        </section>
+        <section id="roofCard" class="rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-xl backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">Roof Controls</h2>
+            <p class="text-sm text-slate-600 dark:text-slate-300/80">Command roof motors and check limit sensors.</p>
+          </div>
+          <div id="roofControls" class="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4"></div>
+        </section>
+        <section class="rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-xl backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">Switches</h2>
+            <p class="text-sm text-slate-600 dark:text-slate-300/80">Toggle observatory equipment with a single tap.</p>
+          </div>
+          <div id="switchesContainer" class="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4"></div>
+        </section>
+        <section class="rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-xl backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">Graphs</h2>
+            <div class="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400"><span class="h-2 w-4 border-t-2 border-slate-400 border-dotted"></span>Dotted segments show values outside the green threshold.</div>
+          </div>
+          <div id="lineChart" class="mt-6 h-64 rounded-2xl bg-slate-900/5 dark:bg-black/30 md:h-96"></div>
+        </section>
+        <section id="skyCamCard" class="rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-xl backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">SkyCam</h2>
+            <p class="text-sm text-slate-600 dark:text-slate-300/80">Live feed from the observatory sky camera.</p>
+          </div>
+          <div class="mt-6 overflow-hidden rounded-2xl border border-slate-200/60 dark:border-white/10">
+            <img id="skyCamImage" class="h-auto w-full object-cover" alt="SkyCam" />
+          </div>
+        </section>
+      </div>
+    </main>
   </div>
-  <nav class="px-2 flex-1">
-    <ul class="space-y-2">
-      <li><a class="block px-2 py-1 hover:bg-gray-700" href="http://10.0.179.242" target="_blank">AAGSolo</a></li>
-      <li><a class="block px-2 py-1 hover:bg-gray-700" href="http://data.smeird.com:3000/public-dashboards/9d4866d34e934549a20debd888358718?refresh=1m&from=now-24h&to=now&timezone=browser" target="_blank">Obs Graphs</a></li>
-      <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://data.smeird.com:3000/public-dashboards/2ed28400ef714b6899a67ca635137a59" target="_blank">Weather</a></li>
-      <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://ob.smeird.com" target="_blank">Public obs</a></li>
-      <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://www.smeird.com" target="_blank">Public Weather</a></li>
-      <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="https://clearoutside.com/forecast/51.81/-0.29" target="_blank">Night Forecast</a></li>
-      <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="settings.html">Settings</a></li>
-    </ul>
-  </nav>
-</aside>
-<div class="flex flex-col min-h-screen flex-1">
-  <header class="md:hidden bg-gray-900 text-white p-4 flex items-center justify-between">
-    <div class="text-lg font-bold flex items-center"><a href="/" class="mr-2"><i class="fa-solid fa-binoculars"></i></a>Observatory</div>
-    <button id="menuButton" class="focus:outline-none">
-      <i class="fa-solid fa-bars text-xl"></i>
-    </button>
-  </header>
-  <main class="flex-1 p-4 md:p-6 space-y-8">
-  <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">Dashboard</h1>
-
-  <!-- Sensors -->
-  <section id="sensorCard" class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Sensors</h2>
-    <div id="sensorsContainer" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"></div>
-  </section>
-
-  <!-- Roof -->
-  <section id="roofCard" class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Roof Controls</h2>
-    <div id="roofControls" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4"></div>
-  </section>
-
-  <!-- Switches -->
-  <section class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Switches</h2>
-    <div id="switchesContainer" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"></div>
-  </section>
-
-  <!-- Graphs -->
-  <section class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">Graphs</h2>
-    <div id="lineChart" class="h-64 md:h-96"></div>
-    <div class="flex items-center mt-2 text-xs text-gray-600 dark:text-gray-400">
-      <span class="w-4 border-t-2 border-gray-400 border-dotted mr-2"></span>
-      <span>Dotted segments indicate values outside the green threshold</span>
-    </div>
-  </section>
-
-  <!-- SkyCam -->
-  <section id="skyCamCard" class="bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow p-6">
-    <h2 class="text-xl font-semibold mb-4 text-gray-900 dark:text-gray-100">SkyCam</h2>
-    <img id="skyCamImage" class="w-full h-auto rounded" alt="SkyCam" />
-  </section>
-</main>
-
 </div>
 
 <script type="module">
 import { loadConfig } from './js/mqttConfig.js';
 
 const menuButton = document.getElementById('menuButton');
+const closeSidebar = document.getElementById('closeSidebar');
 const sidebar = document.getElementById('sidebar');
 const overlay = document.getElementById('overlay');
 const themeSelect = document.getElementById('themeSelect');
@@ -99,29 +156,36 @@ function applyChartTheme(isDark) {
   Highcharts.setOptions({
     chart: {
       backgroundColor: 'transparent',
-      style: { color: isDark ? '#f3f4f6' : '#000000' }
+      style: { color: isDark ? '#f3f4f6' : '#0f172a' }
     },
-    title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
+    title: { style: { color: isDark ? '#f3f4f6' : '#0f172a' } },
     xAxis: {
-      labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
-      gridLineColor: isDark ? '#374151' : '#e5e7eb',
-      lineColor: isDark ? '#374151' : '#e5e7eb',
-      tickColor: isDark ? '#374151' : '#e5e7eb'
+      labels: { style: { color: isDark ? '#e2e8f0' : '#0f172a' } },
+      gridLineColor: isDark ? '#1f2937' : '#e2e8f0',
+      lineColor: isDark ? '#334155' : '#cbd5f5',
+      tickColor: isDark ? '#334155' : '#94a3b8'
     },
     yAxis: {
-      labels: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
-      title: { style: { color: isDark ? '#f3f4f6' : '#000000' } },
-      gridLineColor: isDark ? '#374151' : '#e5e7eb',
-      lineColor: isDark ? '#374151' : '#e5e7eb',
-      tickColor: isDark ? '#374151' : '#e5e7eb'
+      labels: { style: { color: isDark ? '#e2e8f0' : '#0f172a' } },
+      title: { style: { color: isDark ? '#e2e8f0' : '#0f172a' } },
+      gridLineColor: isDark ? '#1f2937' : '#e2e8f0',
+      lineColor: isDark ? '#334155' : '#cbd5f5',
+      tickColor: isDark ? '#334155' : '#94a3b8'
     },
-    legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#000000' } },
+    legend: { itemStyle: { color: isDark ? '#f3f4f6' : '#0f172a' } },
     tooltip: {
-      backgroundColor: isDark ? '#1f2937' : '#ffffff',
-      style: { color: isDark ? '#f3f4f6' : '#000000' }
+      backgroundColor: isDark ? '#111827' : '#ffffff',
+      borderColor: isDark ? '#1d4ed8' : '#dbeafe',
+      style: { color: isDark ? '#f3f4f6' : '#0f172a' }
     }
   });
 }
+
+function closeMenu() {
+  sidebar.classList.add('-translate-x-full');
+  overlay.classList.add('hidden');
+}
+
 if (menuButton && sidebar && overlay) {
   const toggleSidebar = () => {
     sidebar.classList.toggle('-translate-x-full');
@@ -129,6 +193,10 @@ if (menuButton && sidebar && overlay) {
   };
   menuButton.addEventListener('click', toggleSidebar);
   overlay.addEventListener('click', toggleSidebar);
+}
+
+if (closeSidebar && overlay) {
+  closeSidebar.addEventListener('click', closeMenu);
 }
 
 if (themeSelect) {
@@ -200,9 +268,9 @@ let roofClosed = false;
 function updateRoofCardBorder() {
   if (!roofCard) return;
   if (roofClosed) {
-    roofCard.classList.remove('border-2', 'border-red-500');
+    roofCard.classList.remove('border-rose-400/70');
   } else {
-    roofCard.classList.add('border-2', 'border-red-500');
+    roofCard.classList.add('border-rose-400/70');
   }
 }
 
@@ -212,19 +280,19 @@ function addSensorCards() {
   const container = document.getElementById('sensorsContainer');
   sensors.forEach(s => {
     const card = document.createElement('div');
-    card.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center justify-between';
+    card.className = 'group relative flex items-center justify-between gap-4 overflow-hidden rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-3 text-slate-800 shadow-sm transition hover:-translate-y-0.5 hover:border-aurora-400/50 hover:shadow-xl dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100';
 
     const left = document.createElement('span');
-    left.className = 'flex items-center';
+    left.className = 'flex items-center gap-3 text-sm font-medium';
     const indicator = document.createElement('span');
-    indicator.className = 'h-3 w-3 rounded-full bg-red-500 mr-2';
+    indicator.className = 'h-3 w-3 rounded-full bg-rose-500 shadow-[0_0_0_3px_rgba(255,255,255,0.35)] dark:shadow-none';
     left.appendChild(indicator);
     const nameSpan = document.createElement('span');
     nameSpan.textContent = s.name;
     left.appendChild(nameSpan);
     if (s.influxMeasurement && s.influxField) {
       const icon = document.createElement('i');
-      icon.className = 'fa-solid fa-chart-line ml-2';
+      icon.className = 'fa-solid fa-chart-line text-aurora-400 transition group-hover:text-aurora-500';
       left.appendChild(icon);
       card.classList.add('cursor-pointer');
       card.addEventListener('click', () => {
@@ -234,7 +302,7 @@ function addSensorCards() {
     card.appendChild(left);
 
     const valueEl = document.createElement('span');
-    valueEl.className = 'sensor-value font-mono';
+    valueEl.className = 'sensor-value font-mono text-base';
     valueEl.textContent = '--';
     valueEl.setAttribute('data-topic', s.path);
     valueEl.setAttribute('data-static', '');
@@ -257,23 +325,23 @@ function addRoofControls() {
   const container = document.getElementById('roofControls');
   if (roof.open.path) {
     const openDiv = document.createElement('div');
-    openDiv.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center justify-between';
-    openDiv.innerHTML = `<span>Open Roof</span><button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200 dark:bg-gray-600" data-topic="${roof.open.path}"><span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span></button>`;
+    openDiv.className = 'flex items-center justify-between gap-4 rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-3 text-slate-800 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100';
+    openDiv.innerHTML = `<span class="text-sm font-medium">Open Roof</span><button class="toggleButton relative inline-flex h-7 w-12 items-center rounded-full bg-slate-300 transition-colors duration-300 ease-out dark:bg-slate-700" data-topic="${roof.open.path}"><span class="inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition"></span></button>`;
     container.appendChild(openDiv);
     topics.add(roof.open.path);
   }
   if (roof.close.path) {
     const closeDiv = document.createElement('div');
-    closeDiv.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center justify-between';
-    closeDiv.innerHTML = `<span>Close Roof</span><button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200 dark:bg-gray-600" data-topic="${roof.close.path}"><span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span></button>`;
+    closeDiv.className = 'flex items-center justify-between gap-4 rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-3 text-slate-800 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100';
+    closeDiv.innerHTML = `<span class="text-sm font-medium">Close Roof</span><button class="toggleButton relative inline-flex h-7 w-12 items-center rounded-full bg-slate-300 transition-colors duration-300 ease-out dark:bg-slate-700" data-topic="${roof.close.path}"><span class="inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition"></span></button>`;
     container.appendChild(closeDiv);
     topics.add(roof.close.path);
   }
   if (roof.open.limit) {
     const openLimitDiv = document.createElement('div');
-    openLimitDiv.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center';
+    openLimitDiv.className = 'flex items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-3 text-sm text-slate-800 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100';
 
-    openLimitDiv.innerHTML = `<span class="mr-2" data-role="label">Roof isn't open</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.open.limit}" data-static></span>`;
+    openLimitDiv.innerHTML = `<span class="font-medium" data-role="label">Roof isn't open</span><span class="h-3 w-3 rounded-full bg-slate-400" data-topic="${roof.open.limit}" data-static></span>`;
 
     container.appendChild(openLimitDiv);
     indicatorEls[roof.open.limit] = {
@@ -285,9 +353,9 @@ function addRoofControls() {
   }
   if (roof.close.limit) {
     const closeLimitDiv = document.createElement('div');
-    closeLimitDiv.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center';
+    closeLimitDiv.className = 'flex items-center gap-3 rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-3 text-sm text-slate-800 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100';
 
-    closeLimitDiv.innerHTML = `<span class="mr-2" data-role="label">Roof isn't closed</span><span class="h-3 w-3 rounded-full bg-gray-400" data-topic="${roof.close.limit}" data-static></span>`;
+    closeLimitDiv.innerHTML = `<span class="font-medium" data-role="label">Roof isn't closed</span><span class="h-3 w-3 rounded-full bg-slate-400" data-topic="${roof.close.limit}" data-static></span>`;
 
     container.appendChild(closeLimitDiv);
     indicatorEls[roof.close.limit] = {
@@ -303,8 +371,8 @@ function addSwitchCards() {
   const container = document.getElementById('switchesContainer');
   switches.forEach(sw => {
     const card = document.createElement('div');
-    card.className = 'p-4 bg-white dark:bg-gray-700 dark:text-gray-200 rounded shadow flex items-center justify-between';
-    card.innerHTML = `<span>${sw.name}</span><button class="toggleButton relative inline-flex h-6 w-11 items-center rounded-full bg-gray-200 dark:bg-gray-600" data-topic="${sw.path}"><span class="inline-block h-4 w-4 transform rounded-full bg-white transition"></span></button>`;
+    card.className = 'flex items-center justify-between gap-4 rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-3 text-slate-800 shadow-sm dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100';
+    card.innerHTML = `<span class="text-sm font-medium">${sw.name}</span><button class="toggleButton relative inline-flex h-7 w-12 items-center rounded-full bg-slate-300 transition-colors duration-300 ease-out dark:bg-slate-700" data-topic="${sw.path}"><span class="inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition"></span></button>`;
     container.appendChild(card);
     topics.add(sw.path);
   });
@@ -331,18 +399,18 @@ function setToggleDisabled(disabled) {
 function updateConnectionStatus(status, info) {
   const dot = document.getElementById('statusDot');
   const text = document.getElementById('statusText');
-  let color = 'bg-red-500';
+  let color = 'bg-rose-500';
   let message = 'Disconnected';
   if (status === 'connected') {
-    color = 'bg-green-500';
+    color = 'bg-emerald-400';
     message = 'Connected';
     setToggleDisabled(false);
   } else if (status === 'reconnecting') {
-    color = 'bg-yellow-500';
+    color = 'bg-amber-400';
     message = 'Reconnecting...';
     setToggleDisabled(true);
   } else if (status === 'connecting') {
-    color = 'bg-yellow-500';
+    color = 'bg-amber-400';
     message = 'Connecting...';
     setToggleDisabled(true);
   } else if (status === 'error') {
@@ -352,7 +420,7 @@ function updateConnectionStatus(status, info) {
   } else {
     setToggleDisabled(true);
   }
-  if (dot) dot.className = `h-2 w-2 rounded-full mr-2 ${color}`;
+  if (dot) dot.className = `mr-3 h-2.5 w-2.5 rounded-full shadow-[0_0_0_4px_rgba(255,255,255,0.12)] ${color}`;
   if (text) text.textContent = message;
 }
 setToggleDisabled(true);
@@ -453,8 +521,8 @@ try {
 
 function updateIndicatorEl(data, value) {
   const el = data.indicator;
-  el.classList.remove('bg-green-500','bg-red-500','bg-gray-400');
-  el.classList.add(value === '1' ? 'bg-green-500' : 'bg-red-500');
+  el.classList.remove('bg-emerald-400','bg-rose-500','bg-slate-400');
+  el.classList.add(value === '1' ? 'bg-emerald-400' : 'bg-rose-500');
   if (data.label) {
     if (data.type === 'open') {
       data.label.textContent = value === '1' ? 'Roof is open' : "Roof isn't open";
@@ -478,11 +546,11 @@ function updateSensorIndicator(topic, value) {
     const isGreen = data.direction === 'above' ? num >= data.green : num <= data.green;
     data.isGreen = isGreen;
     if (isGreen) {
-      data.el.classList.remove('bg-red-500');
-      data.el.classList.add('bg-green-500');
+      data.el.classList.remove('bg-rose-500');
+      data.el.classList.add('bg-emerald-400');
     } else {
-      data.el.classList.remove('bg-green-500');
-      data.el.classList.add('bg-red-500');
+      data.el.classList.remove('bg-emerald-400');
+      data.el.classList.add('bg-rose-500');
     }
   } else {
     data.isGreen = false;
@@ -492,9 +560,9 @@ function updateSensorIndicator(topic, value) {
     const allGreen = Object.values(sensorIndicators).length > 0 &&
       Object.values(sensorIndicators).every(s => s.isGreen);
     if (allGreen) {
-      sensorCard.classList.add('border-2', 'border-green-500');
+      sensorCard.classList.add('border-emerald-400/70');
     } else {
-      sensorCard.classList.remove('border-2', 'border-green-500');
+      sensorCard.classList.remove('border-emerald-400/70');
     }
   }
 }
@@ -504,12 +572,12 @@ function updateToggleButton(topic, value) {
   if (button) {
     const knob = button.querySelector('span');
     if (value === '1') {
-      button.classList.remove('bg-gray-200');
-      button.classList.add('bg-green-500');
+      button.classList.remove('bg-slate-300', 'dark:bg-slate-700');
+      button.classList.add('bg-emerald-500');
       knob.classList.add('translate-x-5');
     } else {
-      button.classList.remove('bg-green-500');
-      button.classList.add('bg-gray-200');
+      button.classList.remove('bg-emerald-500');
+      button.classList.add('bg-slate-300', 'dark:bg-slate-700');
       knob.classList.remove('translate-x-5');
     }
   }

--- a/settings.html
+++ b/settings.html
@@ -2,128 +2,223 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Settings</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['"Plus Jakarta Sans"', 'ui-sans-serif', 'system-ui', 'sans-serif']
+          },
+          colors: {
+            aurora: {
+              200: '#c4d9ff',
+              300: '#92b4ff',
+              400: '#5b8fff',
+              500: '#2d72ff'
+            }
+          }
+        }
+      }
+    };
+  </script>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
-<body class="min-h-screen bg-gradient-to-b from-gray-100 to-gray-200 flex dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100">
-  <aside class="w-64 bg-gray-900 text-white flex-shrink-0 flex flex-col min-h-screen sticky top-0">
-    <div class="p-4 text-lg font-bold flex items-center"><a href="/" class="mr-2"><i class="fa-solid fa-binoculars"></i></a>Observatory</div>
-    <div class="px-4 pb-4">
-      <div class="flex items-center justify-between">
-        <label for="themeSelect" class="text-sm">Theme</label>
-        <select id="themeSelect" class="bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 rounded p-1">
-          <option value="light">Light</option>
-          <option value="dark">Dark</option>
-          <option value="system">System</option>
-        </select>
-      </div>
-    </div>
-    <nav class="px-2 flex-1">
-      <ul class="space-y-2">
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://10.0.179.242" target="_blank">AAGSolo</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://data.smeird.com:3000/public-dashboards/9d4866d34e934549a20debd888358718?refresh=1m&from=now-24h&to=now&timezone=browser" target="_blank">Obs Graphs</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://data.smeird.com:3000/public-dashboards/2ed28400ef714b6899a67ca635137a59" target="_blank">Weather</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://ob.smeird.com" target="_blank">Public obs</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="http://www.smeird.com" target="_blank">Public Weather</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="https://clearoutside.com/forecast/51.81/-0.29" target="_blank">Night Forecast</a></li>
-        <li><a class="block px-2 py-1 hover:bg-gray-700 dark:hover:bg-gray-600" href="settings.html">Settings</a></li>
-      </ul>
-    </nav>
-  </aside>
-  <main class="flex-1 p-6">
-
-    <div class="bg-white dark:bg-gray-700 dark:text-gray-200 p-6 rounded shadow w-full">
-
-    <h1 class="text-xl mb-4 text-gray-900 dark:text-gray-100">Configuration</h1>
-    <form id="settingsForm" class="space-y-6">
-      <section>
-        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">MQTT Server</h2>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <label class="block text-sm font-medium">Host</label>
-            <input name="MQTT_BROKER_URL" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium">Port</label>
-            <input name="MQTT_PORT" type="number" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium">Username</label>
-            <input name="MQTT_USERNAME" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium">Password</label>
-            <input name="MQTT_PASSWORD" type="password" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
-          </div>
-        </div>
-      </section>
-
-      <section>
-        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">InfluxDB</h2>
-        <div class="grid grid-cols-1 sm:grid-cols-4 gap-4">
-          <div>
-            <label class="block text-sm font-medium">Host</label>
-            <input name="INFLUX_HOST" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium">Org</label>
-            <input name="INFLUX_ORG" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium">Bucket</label>
-            <input name="INFLUX_BUCKET" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium">Token</label>
-            <input name="INFLUX_TOKEN" type="password" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
-          </div>
-        </div>
-      </section>
-
-      <section>
-        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">Sensors</h2>
-        <div id="sensorsList" class="space-y-2"></div>
-        <button type="button" id="addSensor" class="mt-2 bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">Add Sensor</button>
-      </section>
-
-      <section>
-        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">Roof</h2>
-        <div class="space-y-2">
-          <div class="flex space-x-2">
-            <input id="roofOpenPath" class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 flex-1" placeholder="Open Path" />
-            <input id="roofOpenLimit" class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 flex-1" placeholder="Roof Open Status Topic" />
-          </div>
-          <div class="flex space-x-2">
-            <input id="roofClosePath" class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 flex-1" placeholder="Close Path" />
-            <input id="roofCloseLimit" class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 flex-1" placeholder="Roof Closed Status Topic" />
-          </div>
-        </div>
-      </section>
-
-      <section>
-        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">Switches</h2>
-        <div id="switchesList" class="space-y-2"></div>
-        <button type="button" id="addSwitch" class="mt-2 bg-gray-200 dark:bg-gray-600 text-gray-900 dark:text-gray-100 px-2 py-1 rounded">Add Switch</button>
-      </section>
-
-      <section>
-        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">SkyCam Topic</h2>
-        <input name="MQTT_SKYCAM_TOPIC" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
-      </section>
-
-      <section>
-        <h2 class="text-lg font-semibold mb-2 text-gray-900 dark:text-gray-100">Dashboard Topics (comma separated)</h2>
-        <input name="MQTT_DASHBOARD_TOPICS" class="mt-1 p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-full" />
-      </section>
-
-      <button type="submit" class="bg-blue-500 dark:bg-blue-600 text-white px-4 py-2 rounded">Save</button>
-    </form>
-    <div id="status" class="mt-4 text-sm"></div>
+<body class="min-h-screen font-sans antialiased text-slate-900 dark:text-slate-100">
+  <div class="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+    <div class="absolute inset-0 bg-gradient-to-br from-slate-100 via-white to-slate-200 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950"></div>
+    <div class="absolute left-1/2 top-[-10%] h-[520px] w-[520px] -translate-x-1/2 rounded-full bg-aurora-300/40 blur-3xl dark:bg-aurora-500/30"></div>
+    <div class="absolute bottom-[-25%] right-[-10%] h-[480px] w-[480px] rounded-full bg-aurora-200/40 blur-3xl dark:bg-aurora-400/20"></div>
+    <div class="absolute left-[-15%] top-1/3 h-72 w-72 rounded-full bg-white/40 blur-3xl dark:bg-white/5"></div>
   </div>
-  </main>
+  <div id="overlay" class="fixed inset-0 z-30 bg-slate-900/60 backdrop-blur-sm hidden md:hidden"></div>
+  <div class="relative z-10 min-h-screen md:flex">
+    <aside id="sidebar" class="fixed inset-y-0 left-0 z-40 flex w-72 -translate-x-full transform flex-col border-r border-white/10 bg-slate-900/80 px-6 pb-6 pt-8 text-slate-100 backdrop-blur-lg transition-transform duration-300 md:relative md:translate-x-0 md:flex-shrink-0 md:border-r md:border-slate-200/20">
+      <div class="mb-8 flex items-center justify-between">
+        <a href="/" class="flex items-center gap-3 text-lg font-semibold tracking-tight">
+          <span class="grid h-10 w-10 place-items-center rounded-2xl bg-white/10 text-aurora-200 shadow ring-1 ring-white/20"><i class="fa-solid fa-binoculars"></i></span>
+          <span class="leading-tight">Observatory</span>
+        </a>
+        <button id="closeSidebar" class="md:hidden text-slate-300 transition hover:text-white" aria-label="Close menu">
+          <i class="fa-solid fa-xmark text-xl"></i>
+        </button>
+      </div>
+      <div class="space-y-6 overflow-y-auto">
+        <div class="rounded-2xl border border-white/10 bg-white/10 p-4 shadow-inner backdrop-blur">
+          <div class="flex items-center justify-between text-xs uppercase tracking-wide text-slate-200/80">
+            <span>Theme</span>
+            <i class="fa-solid fa-circle-half-stroke text-aurora-200"></i>
+          </div>
+          <select id="themeSelect" class="mt-3 w-full rounded-xl border border-white/10 bg-slate-900/80 px-3 py-2 text-sm font-medium text-slate-100 shadow-sm outline-none transition focus:border-aurora-400 focus:ring-2 focus:ring-aurora-300/40">
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+            <option value="system">System</option>
+          </select>
+        </div>
+        <nav class="space-y-2 text-sm font-medium">
+          <p class="px-3 text-xs uppercase tracking-[0.3em] text-slate-200/60">Quick Links</p>
+          <ul class="space-y-2">
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://10.0.179.242" target="_blank"><i class="fa-solid fa-mountain-sun text-aurora-200"></i><span>AAGSolo</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://data.smeird.com:3000/public-dashboards/9d4866d34e934549a20debd888358718?refresh=1m&amp;from=now-24h&amp;to=now&amp;timezone=browser" target="_blank"><i class="fa-solid fa-chart-line text-aurora-200"></i><span>Obs Graphs</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://data.smeird.com:3000/public-dashboards/2ed28400ef714b6899a67ca635137a59" target="_blank"><i class="fa-solid fa-cloud-sun text-aurora-200"></i><span>Weather</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://ob.smeird.com" target="_blank"><i class="fa-solid fa-earth-europe text-aurora-200"></i><span>Public obs</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="http://www.smeird.com" target="_blank"><i class="fa-solid fa-droplet text-aurora-200"></i><span>Public Weather</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="https://clearoutside.com/forecast/51.81/-0.29" target="_blank"><i class="fa-solid fa-moon-stars text-aurora-200"></i><span>Night Forecast</span></a></li>
+            <li><a class="flex items-center gap-3 rounded-xl border border-transparent bg-white/5 px-3 py-2 text-slate-200 transition hover:-translate-y-0.5 hover:border-white/10 hover:bg-white/10 hover:text-white" href="settings.html"><i class="fa-solid fa-sliders text-aurora-200"></i><span>Settings</span></a></li>
+          </ul>
+        </nav>
+      </div>
+    </aside>
+    <div class="flex min-h-screen flex-1 flex-col">
+      <header class="flex items-center justify-between gap-4 bg-white/80 px-6 py-4 shadow-sm backdrop-blur dark:bg-slate-900/70 md:hidden">
+        <div class="flex items-center gap-3 text-base font-semibold text-slate-700 dark:text-slate-100">
+          <span class="grid h-9 w-9 place-items-center rounded-2xl bg-aurora-400/20 text-aurora-500 dark:bg-aurora-500/20"><i class="fa-solid fa-binoculars"></i></span>
+          Observatory
+        </div>
+        <button id="menuButton" class="rounded-xl border border-slate-200 bg-white/80 px-3 py-2 text-slate-700 shadow-sm transition hover:-translate-y-0.5 hover:bg-white dark:border-white/10 dark:bg-slate-800/80 dark:text-slate-100" aria-label="Open menu">
+          <i class="fa-solid fa-bars text-lg"></i>
+        </button>
+      </header>
+      <main class="flex-1 px-4 py-10 sm:px-8">
+        <div class="mx-auto flex w-full max-w-5xl flex-col gap-8">
+          <div class="flex flex-col gap-3">
+            <p class="text-sm uppercase tracking-[0.35em] text-slate-500/70 dark:text-slate-300/60">Configuration</p>
+            <h1 class="text-4xl font-semibold tracking-tight text-slate-900 dark:text-white"><span class="bg-gradient-to-r from-aurora-400 via-blue-500 to-purple-500 bg-clip-text text-transparent">Settings</span></h1>
+            <p class="max-w-3xl text-sm text-slate-600 dark:text-slate-300/80">Update MQTT, InfluxDB, and dashboard behaviour with streamlined controls. Changes take effect immediately after saving.</p>
+          </div>
+          <div class="rounded-3xl border border-slate-200/60 bg-white/80 p-8 shadow-xl backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
+            <form id="settingsForm" class="space-y-10">
+              <section class="space-y-4">
+                <div class="flex flex-col gap-1">
+                  <h2 class="text-xl font-semibold text-slate-900 dark:text-white">MQTT Server</h2>
+                  <p class="text-sm text-slate-600 dark:text-slate-300/80">Provide connection details for the observatory broker.</p>
+                </div>
+                <div class="grid gap-4 sm:grid-cols-2">
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-slate-700 dark:text-slate-200">Host</label>
+                    <input name="MQTT_BROKER_URL" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-slate-700 dark:text-slate-200">Port</label>
+                    <input name="MQTT_PORT" type="number" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-slate-700 dark:text-slate-200">Username</label>
+                    <input name="MQTT_USERNAME" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-slate-700 dark:text-slate-200">Password</label>
+                    <input name="MQTT_PASSWORD" type="password" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                  </div>
+                </div>
+              </section>
+
+              <section class="space-y-4">
+                <div class="flex flex-col gap-1">
+                  <h2 class="text-xl font-semibold text-slate-900 dark:text-white">InfluxDB</h2>
+                  <p class="text-sm text-slate-600 dark:text-slate-300/80">Configure historical storage and query access.</p>
+                </div>
+                <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-slate-700 dark:text-slate-200">Host</label>
+                    <input name="INFLUX_HOST" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-slate-700 dark:text-slate-200">Org</label>
+                    <input name="INFLUX_ORG" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-slate-700 dark:text-slate-200">Bucket</label>
+                    <input name="INFLUX_BUCKET" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    <label class="text-sm font-medium text-slate-700 dark:text-slate-200">Token</label>
+                    <input name="INFLUX_TOKEN" type="password" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                  </div>
+                </div>
+              </section>
+
+              <section class="space-y-4">
+                <div class="flex flex-col gap-1">
+                  <h2 class="text-xl font-semibold text-slate-900 dark:text-white">Sensors</h2>
+                  <p class="text-sm text-slate-600 dark:text-slate-300/80">Define sensor names, MQTT topics, thresholds, and history metadata.</p>
+                </div>
+                <div id="sensorsList" class="space-y-3"></div>
+                <button type="button" id="addSensor" class="inline-flex items-center gap-2 rounded-xl border border-aurora-300/50 bg-aurora-300/20 px-4 py-2 text-sm font-semibold text-aurora-600 transition hover:-translate-y-0.5 hover:bg-aurora-300/30 dark:border-aurora-500/40 dark:bg-aurora-500/10 dark:text-aurora-200"> <i class="fa-solid fa-plus"></i> Add Sensor</button>
+              </section>
+
+              <section class="space-y-4">
+                <div class="flex flex-col gap-1">
+                  <h2 class="text-xl font-semibold text-slate-900 dark:text-white">Roof</h2>
+                  <p class="text-sm text-slate-600 dark:text-slate-300/80">MQTT topics for motor control and position feedback.</p>
+                </div>
+                <div class="grid gap-3 sm:grid-cols-2">
+                  <input id="roofOpenPath" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" placeholder="Open Path" />
+                  <input id="roofOpenLimit" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" placeholder="Roof Open Status Topic" />
+                  <input id="roofClosePath" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" placeholder="Close Path" />
+                  <input id="roofCloseLimit" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" placeholder="Roof Closed Status Topic" />
+                </div>
+              </section>
+
+              <section class="space-y-4">
+                <div class="flex flex-col gap-1">
+                  <h2 class="text-xl font-semibold text-slate-900 dark:text-white">Switches</h2>
+                  <p class="text-sm text-slate-600 dark:text-slate-300/80">Create quick toggles for auxiliary equipment.</p>
+                </div>
+                <div id="switchesList" class="space-y-3"></div>
+                <button type="button" id="addSwitch" class="inline-flex items-center gap-2 rounded-xl border border-aurora-300/50 bg-aurora-300/20 px-4 py-2 text-sm font-semibold text-aurora-600 transition hover:-translate-y-0.5 hover:bg-aurora-300/30 dark:border-aurora-500/40 dark:bg-aurora-500/10 dark:text-aurora-200"><i class="fa-solid fa-plus"></i> Add Switch</button>
+              </section>
+
+              <section class="grid gap-4 sm:grid-cols-2">
+                <div class="flex flex-col gap-2">
+                  <h2 class="text-sm font-semibold text-slate-700 dark:text-slate-200">SkyCam Topic</h2>
+                  <input name="MQTT_SKYCAM_TOPIC" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                </div>
+                <div class="flex flex-col gap-2">
+                  <h2 class="text-sm font-semibold text-slate-700 dark:text-slate-200">Dashboard Topics (comma separated)</h2>
+                  <input name="MQTT_DASHBOARD_TOPICS" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                </div>
+              </section>
+
+              <div class="flex flex-col gap-3">
+                <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-aurora-400 via-blue-500 to-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-aurora-300/30 transition hover:shadow-xl hover:shadow-aurora-300/40">
+                  <i class="fa-solid fa-floppy-disk"></i> Save Configuration
+                </button>
+                <div id="status" class="text-sm text-rose-500"></div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+
   <script type="module">
     import { loadConfig } from './js/mqttConfig.js';
+
+    const menuButton = document.getElementById('menuButton');
+    const closeSidebar = document.getElementById('closeSidebar');
+    const sidebar = document.getElementById('sidebar');
+    const overlay = document.getElementById('overlay');
+
+    function toggleSidebar() {
+      sidebar.classList.toggle('-translate-x-full');
+      overlay.classList.toggle('hidden');
+    }
+
+    if (menuButton && sidebar && overlay) {
+      menuButton.addEventListener('click', toggleSidebar);
+      overlay.addEventListener('click', toggleSidebar);
+    }
+
+    if (closeSidebar) {
+      closeSidebar.addEventListener('click', toggleSidebar);
+    }
 
     const themeSelect = document.getElementById('themeSelect');
     if (themeSelect) {
@@ -154,32 +249,36 @@
     const sensorsList = document.getElementById('sensorsList');
     const switchesList = document.getElementById('switchesList');
 
+    const inputBase = 'rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100';
+    const selectBase = 'rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100';
+    const rowBase = 'flex flex-wrap items-center gap-2 rounded-2xl border border-slate-200/70 bg-white/70 px-3 py-3 shadow-sm dark:border-white/10 dark:bg-slate-900/60';
+
     function createSensorRow(data = {}) {
       const row = document.createElement('div');
-      row.className = 'flex space-x-2 sensor-row';
+      row.className = `${rowBase} sensor-row`;
       row.innerHTML = `
-        <input class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 flex-1 sensor-path" placeholder="Path" value="${data.path || ''}">
-        <input class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-24 sensor-unit" placeholder="Unit" value="${data.unit || ''}">
-        <input class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 flex-1 sensor-name" placeholder="Name" value="${data.name || ''}">
-        <input class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-24 sensor-green" type="number" step="any" placeholder="Green" value="${data.green || ''}">
-        <select class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-28 sensor-direction">
+        <input class="${inputBase} flex-1 min-w-[10rem] sensor-path" placeholder="Path" value="${data.path || ''}">
+        <input class="${inputBase} w-28 sensor-unit" placeholder="Unit" value="${data.unit || ''}">
+        <input class="${inputBase} flex-1 min-w-[10rem] sensor-name" placeholder="Name" value="${data.name || ''}">
+        <input class="${inputBase} w-28 sensor-green" type="number" step="any" placeholder="Green" value="${data.green || ''}">
+        <select class="${selectBase} w-32 sensor-direction">
           <option value="below" ${data.greenDirection === 'above' ? '' : 'selected'}>Below</option>
           <option value="above" ${data.greenDirection === 'above' ? 'selected' : ''}>Above</option>
         </select>
-        <input class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-32 sensor-measurement" placeholder="Measurement" value="${data.influxMeasurement || ''}">
-        <input class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 w-32 sensor-field" placeholder="Field" value="${data.influxField || ''}">
-        <button type="button" class="remove bg-red-500 dark:bg-red-600 text-white px-2 rounded"><i class="fa-solid fa-xmark"></i></button>`;
+        <input class="${inputBase} w-40 sensor-measurement" placeholder="Measurement" value="${data.influxMeasurement || ''}">
+        <input class="${inputBase} w-40 sensor-field" placeholder="Field" value="${data.influxField || ''}">
+        <button type="button" class="remove inline-flex h-10 w-10 items-center justify-center rounded-xl bg-rose-500/80 text-white shadow transition hover:bg-rose-500"><i class="fa-solid fa-xmark"></i></button>`;
       row.querySelector('.remove').addEventListener('click', () => row.remove());
       sensorsList.appendChild(row);
     }
 
     function createSwitchRow(data = {}) {
       const row = document.createElement('div');
-      row.className = 'flex space-x-2 switch-row';
+      row.className = `${rowBase} switch-row`;
       row.innerHTML = `
-        <input class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 flex-1 switch-path" placeholder="Path" value="${data.path || ''}">
-        <input class="p-2 border border-gray-300 dark:border-gray-500 bg-white dark:bg-gray-600 text-gray-900 dark:text-gray-100 flex-1 switch-name" placeholder="Name" value="${data.name || ''}">
-        <button type="button" class="remove bg-red-500 dark:bg-red-600 text-white px-2 rounded"><i class="fa-solid fa-xmark"></i></button>`;
+        <input class="${inputBase} flex-1 min-w-[10rem] switch-path" placeholder="Path" value="${data.path || ''}">
+        <input class="${inputBase} flex-1 min-w-[8rem] switch-name" placeholder="Name" value="${data.name || ''}">
+        <button type="button" class="remove inline-flex h-10 w-10 items-center justify-center rounded-xl bg-rose-500/80 text-white shadow transition hover:bg-rose-500"><i class="fa-solid fa-xmark"></i></button>`;
       row.querySelector('.remove').addEventListener('click', () => row.remove());
       switchesList.appendChild(row);
     }


### PR DESCRIPTION
## Summary
- refresh the dashboard, history, and settings layouts with a glassmorphism-inspired Tailwind treatment, aurora gradient flourishes, and a Plus Jakarta Sans typeface
- modernize cards, toggles, and navigation with rounded geometry, hover depth, and cohesive color accents while keeping all existing MQTT-driven functionality intact
- ensure mobile sidebar interactions, chart theming, and settings form controls adopt the updated design without altering behaviour
- align the main content with the sidebar on desktop by removing an extra margin that pushed cards too far right

## Testing
- npm test *(fails: no package.json present)*

------
https://chatgpt.com/codex/tasks/task_e_68cac2e755a8832ebe4df6f9ff16ef9a