### PR TITLE
Ensure theme toggle supports Tailwind dark mode

### DIFF
--- a/history.html
+++ b/history.html
@@ -8,7 +8,14 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script>
+    const savedTheme = localStorage.getItem('theme') || 'system';
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const enableDark = savedTheme === 'dark' || (savedTheme === 'system' && prefersDark);
+    document.documentElement.classList.toggle('dark', enableDark);
+  </script>
+  <script>
     tailwind.config = {
+      darkMode: 'class',
       theme: {
         extend: {
           fontFamily: {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,14 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
 <script>
+  const savedTheme = localStorage.getItem('theme') || 'system';
+  const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const enableDark = savedTheme === 'dark' || (savedTheme === 'system' && prefersDark);
+  document.documentElement.classList.toggle('dark', enableDark);
+</script>
+<script>
   tailwind.config = {
+    darkMode: 'class',
     theme: {
       extend: {
         fontFamily: {

--- a/settings.html
+++ b/settings.html
@@ -8,7 +8,14 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <script>
+    const savedTheme = localStorage.getItem('theme') || 'system';
+    const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const enableDark = savedTheme === 'dark' || (savedTheme === 'system' && prefersDark);
+    document.documentElement.classList.toggle('dark', enableDark);
+  </script>
+  <script>
     tailwind.config = {
+      darkMode: 'class',
       theme: {
         extend: {
           fontFamily: {


### PR DESCRIPTION
## Summary
- ensure each page sets the saved theme immediately before Tailwind loads so the correct mode renders on first paint
- configure the Tailwind CDN runtime for class-based dark mode so toggling the `dark` class updates the UI

## Testing
- npm test *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68cad4a703ec832ea925788fccb6a32f