### PR TITLE
Fix mobile sidebar overlay to stay visible

### DIFF
--- a/history.html
+++ b/history.html
@@ -125,15 +125,35 @@
     const closeSidebar = document.getElementById('closeSidebar');
     const sidebar = document.getElementById('sidebar');
     const overlay = document.getElementById('overlay');
+
+    function openMenu() {
+      if (!sidebar || !overlay) return;
+      sidebar.classList.remove('-translate-x-full');
+      overlay.classList.remove('hidden');
+      overlay.style.left = `${sidebar.offsetWidth}px`;
+      document.body.classList.add('overflow-hidden');
+    }
+
+    function closeMenu() {
+      if (!sidebar || !overlay) return;
+      sidebar.classList.add('-translate-x-full');
+      overlay.classList.add('hidden');
+      overlay.style.left = '';
+      document.body.classList.remove('overflow-hidden');
+    }
+
     if (menuButton && sidebar && overlay) {
       const toggleSidebar = () => {
-        sidebar.classList.toggle('-translate-x-full');
-        overlay.classList.toggle('hidden');
+        if (sidebar.classList.contains('-translate-x-full')) {
+          openMenu();
+        } else {
+          closeMenu();
+        }
       };
       menuButton.addEventListener('click', toggleSidebar);
       overlay.addEventListener('click', toggleSidebar);
       if (closeSidebar) {
-        closeSidebar.addEventListener('click', toggleSidebar);
+        closeSidebar.addEventListener('click', closeMenu);
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -191,15 +191,29 @@ function applyChartTheme(isDark) {
   });
 }
 
+function openMenu() {
+  if (!sidebar || !overlay) return;
+  sidebar.classList.remove('-translate-x-full');
+  overlay.classList.remove('hidden');
+  overlay.style.left = `${sidebar.offsetWidth}px`;
+  document.body.classList.add('overflow-hidden');
+}
+
 function closeMenu() {
+  if (!sidebar || !overlay) return;
   sidebar.classList.add('-translate-x-full');
   overlay.classList.add('hidden');
+  overlay.style.left = '';
+  document.body.classList.remove('overflow-hidden');
 }
 
 if (menuButton && sidebar && overlay) {
   const toggleSidebar = () => {
-    sidebar.classList.toggle('-translate-x-full');
-    overlay.classList.toggle('hidden');
+    if (sidebar.classList.contains('-translate-x-full')) {
+      openMenu();
+    } else {
+      closeMenu();
+    }
   };
   menuButton.addEventListener('click', toggleSidebar);
   overlay.addEventListener('click', toggleSidebar);

--- a/settings.html
+++ b/settings.html
@@ -216,18 +216,36 @@
     const sidebar = document.getElementById('sidebar');
     const overlay = document.getElementById('overlay');
 
-    function toggleSidebar() {
-      sidebar.classList.toggle('-translate-x-full');
-      overlay.classList.toggle('hidden');
+    function openMenu() {
+      if (!sidebar || !overlay) return;
+      sidebar.classList.remove('-translate-x-full');
+      overlay.classList.remove('hidden');
+      overlay.style.left = `${sidebar.offsetWidth}px`;
+      document.body.classList.add('overflow-hidden');
+    }
+
+    function closeMenu() {
+      if (!sidebar || !overlay) return;
+      sidebar.classList.add('-translate-x-full');
+      overlay.classList.add('hidden');
+      overlay.style.left = '';
+      document.body.classList.remove('overflow-hidden');
     }
 
     if (menuButton && sidebar && overlay) {
+      const toggleSidebar = () => {
+        if (sidebar.classList.contains('-translate-x-full')) {
+          openMenu();
+        } else {
+          closeMenu();
+        }
+      };
       menuButton.addEventListener('click', toggleSidebar);
       overlay.addEventListener('click', toggleSidebar);
     }
 
-    if (closeSidebar) {
-      closeSidebar.addEventListener('click', toggleSidebar);
+    if (closeSidebar && overlay) {
+      closeSidebar.addEventListener('click', closeMenu);
     }
 
     const themeSelect = document.getElementById('themeSelect');


### PR DESCRIPTION
## Summary
- ensure the mobile overlay offsets to the sidebar width so the menu stays visible when opened
- reuse the same open/close helpers across index, settings, and history pages and lock body scrolling while the drawer is open

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da9f2d443c832e87cc42a9f68283aa