### PR TITLE
Make Highcharts backgrounds transparent

### DIFF
--- a/history.html
+++ b/history.html
@@ -169,6 +169,8 @@
       Highcharts.setOptions({
         chart: {
           backgroundColor: 'transparent',
+          plotBackgroundColor: 'transparent',
+          plotBorderWidth: 0,
           style: { color: isDark ? '#f3f4f6' : '#0f172a' }
         },
         title: { style: { color: isDark ? '#f3f4f6' : '#0f172a' } },
@@ -280,6 +282,11 @@
             return [new Date(parts[timeIdx]).getTime(), parseFloat(parts[valueIdx])];
           });
           historyChart = Highcharts.chart('historyChart', {
+            chart: {
+              backgroundColor: 'transparent',
+              plotBackgroundColor: 'transparent',
+              plotBorderWidth: 0
+            },
             title: { text: null },
             xAxis: { type: 'datetime' },
             yAxis: { title: { text: sensor.unit || null } },

--- a/index.html
+++ b/index.html
@@ -166,6 +166,8 @@ function applyChartTheme(isDark) {
   Highcharts.setOptions({
     chart: {
       backgroundColor: 'transparent',
+      plotBackgroundColor: 'transparent',
+      plotBorderWidth: 0,
       style: { color: isDark ? '#f3f4f6' : '#0f172a' }
     },
     title: { style: { color: isDark ? '#f3f4f6' : '#0f172a' } },
@@ -488,7 +490,12 @@ function initLineChart() {
     return { name: s.name, data: [], yAxis: idx, zones, tooltip: { valueSuffix: s.unit ? ` ${s.unit}` : '' } };
   });
   lineChart = Highcharts.chart('lineChart', {
-    chart: { type: 'line' },
+    chart: {
+      type: 'line',
+      backgroundColor: 'transparent',
+      plotBackgroundColor: 'transparent',
+      plotBorderWidth: 0
+    },
     title: { text: null },
     xAxis: { type: 'datetime' },
     yAxis,


### PR DESCRIPTION
## Summary
- ensure the shared Highcharts theme uses transparent chart and plot backgrounds
- explicitly set transparent backgrounds on the dashboard and history charts

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daa3123fe4832eac4e73e7484af567