### PR TITLE
Make roof controls resilient to unknown MQTT state

### DIFF
--- a/index.html
+++ b/index.html
@@ -281,6 +281,7 @@ try {
 const roofEspBase = 'Observatory/roof-esp';
 const roofEsp = {
   state: {
+    online: `${roofEspBase}/online`,
     openLimit: `${roofEspBase}/open_limit`,
     closeLimit: `${roofEspBase}/close_limit`,
     moving: `${roofEspBase}/moving`,
@@ -536,11 +537,13 @@ function addRoofControls() {
     container.appendChild(item.card);
   });
 
+  topics.add(roofEsp.state.online);
   topics.add(roofEsp.state.openMotor);
   topics.add(roofEsp.state.closeMotor);
   topics.add(roofEsp.state.moving);
   topics.add(roofEsp.state.enabled);
   topics.add(roofEsp.state.fault);
+  topics.add(roofEsp.state.faultCode);
   topics.add(roofEsp.state.heartbeat);
 
   roofMotionButtons.open = openAction.button;
@@ -571,6 +574,7 @@ function addRoofStatus() {
   if (!container) return;
   container.innerHTML = '';
   const items = [
+    { label: 'Online', topic: roofEsp.state.online },
     { label: 'Moving', topic: roofEsp.state.moving },
     { label: 'Open limit', topic: roofEsp.state.openLimit },
     { label: 'Close limit', topic: roofEsp.state.closeLimit },
@@ -637,8 +641,8 @@ function updateConnectionStatus(status, info) {
   if (status === 'connected') {
     color = 'bg-emerald-400';
     message = 'Connected';
-    setControlsDisabled(false);
     mqttConnected = true;
+    setControlsDisabled(false);
   } else if (status === 'reconnecting') {
     color = 'bg-amber-400';
     message = 'Reconnecting...';
@@ -771,8 +775,7 @@ try {
     button.addEventListener('click', function() {
       const stateTopic = this.getAttribute('data-topic');
       const commandTopic = this.getAttribute('data-command-topic');
-      const currentState = stateValues[stateTopic];
-      if (currentState !== '0' && currentState !== '1') return;
+      const currentState = stateValues[stateTopic] === '1' ? '1' : '0';
       const newState = currentState === '1' ? '0' : '1';
       sendCommand(commandTopic, newState);
     });
@@ -837,6 +840,7 @@ function updateHeartbeatDisplay() {
   if (!lastHeartbeatAt) {
     el.textContent = 'Waiting...';
     setStatusTone(el, 'warn');
+    updateMotionButtons();
     return;
   }
   const now = new Date();
@@ -848,6 +852,7 @@ function updateHeartbeatDisplay() {
     el.textContent = `Last seen ${formatTimestamp(lastHeartbeatAt)}`;
     setStatusTone(el, 'good');
   }
+  updateMotionButtons();
 }
 
 function updateStatusValue(topic, value) {
@@ -858,6 +863,17 @@ function updateStatusValue(topic, value) {
   if (topic === roofEsp.state.moving) {
     text = value === '1' ? 'Moving' : 'Stopped';
     tone = value === '1' ? 'warn' : 'good';
+  } else if (topic === roofEsp.state.online) {
+    if (value === '1') {
+      text = 'Online';
+      tone = 'good';
+    } else if (value === '0') {
+      text = 'Offline';
+      tone = 'bad';
+    } else {
+      text = 'Unknown';
+      tone = 'warn';
+    }
   } else if (topic === roofEsp.state.openLimit) {
     text = value === '1' ? 'Roof is open' : "Roof isn't open";
     tone = value === '1' ? 'good' : 'neutral';
@@ -895,22 +911,31 @@ function updateMotionButtons() {
   const fault = stateValues[roofEsp.state.fault];
   const openLimit = stateValues[roofEsp.state.openLimit];
   const closeLimit = stateValues[roofEsp.state.closeLimit];
-  const baseAllowed = enabled === '1' && fault === '0';
+  const online = stateValues[roofEsp.state.online];
+  const heartbeatStale = lastHeartbeatAt
+    ? (new Date() - lastHeartbeatAt) > 90000
+    : false;
+  const baseAllowed = enabled !== '0' && fault !== '1';
+  const motorAllowed = mqttConnected && online !== '0' && !heartbeatStale;
 
   if (roofMotionButtons.open) {
-    roofMotionButtons.open.disabled = !baseAllowed || openLimit !== '0';
+    roofMotionButtons.open.disabled = !motorAllowed || !baseAllowed || openLimit === '1';
   }
   if (roofMotionButtons.close) {
-    roofMotionButtons.close.disabled = !baseAllowed || closeLimit !== '0';
+    roofMotionButtons.close.disabled = !motorAllowed || !baseAllowed || closeLimit === '1';
+  }
+  if (roofMotionButtons.stop) {
+    roofMotionButtons.stop.disabled = !motorAllowed;
   }
 }
 
 function updateRelayLockout() {
   if (!mqttConnected) return;
   const moving = stateValues[roofEsp.state.moving];
+  const online = stateValues[roofEsp.state.online];
   relayToggleButtons.forEach(button => {
     if (!button) return;
-    const shouldDisable = moving === '1';
+    const shouldDisable = online === '0' || moving === '1';
     button.disabled = shouldDisable;
     button.classList.toggle('opacity-50', shouldDisable);
     button.classList.toggle('cursor-not-allowed', shouldDisable);


### PR DESCRIPTION
### Motivation
- The UI previously blocked user actions until retained device state topics contained explicit `0`/`1` values, causing the interface to lock when the broker was cleared or the ESP rebooted. 
- The goal is to allow controls when the MQTT connection is present while still reflecting device availability and preventing unsafe motor commands.

### Description
- Added a new state topic `roofEsp.state.online = \\`${roofEspBase}/online\\`` and subscribed to it; added an "Online" row to the Roof Status panel and included `faultCode` in the subscribed topics. 
- Relaxed toggle click handling so the handler no longer returns when state is unknown; it assumes `0` (off) when `stateValues` isn't `0`/`1`, inverts that assumed/current state and publishes the command with `qos:1` while using `updateCommandStatus` for optimistic feedback and not mutating `stateValues` directly. 
- Updated `updateStatusValue` to render `Online`/`Offline`/`Unknown` for the new `online` topic and added heartbeat-triggered calls to `updateMotionButtons`. 
- Reworked `updateMotionButtons` and `updateRelayLockout` so unknown `enabled`/`fault` values are permissive, motor commands are blocked only when device is explicitly offline or heartbeat is stale, and relay toggles are only locked for explicit offline or active motion.

### Testing
- No automated tests are configured and no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697266467ef0832eaf715a5fe60ae089)