### PR TITLE
Add auxiliary switches section to dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,3 +51,4 @@
 
 - Sidebar includes a theme selector (Light/Dark/System) storing preference in `localStorage`. The `dark` class on `<html>` follows the selected theme, with `System` using `prefers-color-scheme`.
 - Interactive elements like buttons and form inputs should provide matching `dark:` variants for colors and borders.
+- Auxiliary switches on the dashboard are driven by the settings `switches` list and render in their own section below the primary roof relay switches.

--- a/index.html
+++ b/index.html
@@ -141,6 +141,13 @@
         </section>
         <section class="rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-xl backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
           <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">Auxiliary Switches</h2>
+            <p class="text-sm text-slate-600 dark:text-slate-300/80">Additional MQTT-controlled toggles configured in settings.</p>
+          </div>
+          <div id="auxSwitchesContainer" class="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4"></div>
+        </section>
+        <section class="rounded-3xl border border-slate-200/60 bg-white/80 p-6 shadow-xl backdrop-blur dark:border-white/10 dark:bg-slate-900/60">
+          <div class="flex flex-wrap items-center justify-between gap-4">
             <h2 class="text-2xl font-semibold text-slate-900 dark:text-white">Graphs</h2>
             <div class="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400"><span class="h-2 w-4 border-t-2 border-slate-400 border-dotted"></span>Dotted segments show values outside the green threshold.</div>
           </div>
@@ -268,9 +275,9 @@ if (themeSelect) {
   applyChartTheme(false);
 }
 
-let brokerUrl, port, username, password, dashboardTopics, sensors, skyCamTopic;
+let brokerUrl, port, username, password, dashboardTopics, sensors, skyCamTopic, switches;
 try {
-  ({ brokerUrl, port, username, password, dashboardTopics, sensors, skyCamTopic } = await loadConfig());
+  ({ brokerUrl, port, username, password, dashboardTopics, sensors, skyCamTopic, switches } = await loadConfig());
 } catch (err) {
   const statusEl = document.getElementById('statusText');
   if (statusEl) statusEl.textContent = 'Error connecting to MQTT';
@@ -569,6 +576,26 @@ function addSwitchCards() {
   });
 }
 
+function addAuxSwitchCards() {
+  const container = document.getElementById('auxSwitchesContainer');
+  if (!container) return;
+  if (!Array.isArray(switches) || switches.length === 0) {
+    container.innerHTML = '<p class="text-sm text-slate-500 dark:text-slate-400">No auxiliary switches configured yet.</p>';
+    return;
+  }
+  switches.forEach(sw => {
+    if (!sw.path) return;
+    const { card } = createToggleCard({
+      label: sw.name || sw.path,
+      description: 'Auxiliary MQTT integration.',
+      stateTopic: sw.path,
+      commandTopic: sw.path
+    });
+    container.appendChild(card);
+    topics.add(sw.path);
+  });
+}
+
 function addRoofStatus() {
   const container = document.getElementById('roofStatus');
   if (!container) return;
@@ -610,6 +637,7 @@ function addRoofStatus() {
 addSensorCards();
 addRoofControls();
 addSwitchCards();
+addAuxSwitchCards();
 addRoofStatus();
 initLineChart();
 setInterval(updateHeartbeatDisplay, 5000);


### PR DESCRIPTION
### Motivation
- Restore visibility of additional MQTT-managed switches defined in settings and keep the existing roof relay controls intact.
- Surface those auxiliary toggles on the main dashboard in a dedicated area so they are easier to find and manage.

### Description
- Added an `Auxiliary Switches` card to `index.html` containing `#auxSwitchesContainer` to render settings-defined switches below the existing relay switches.
- Updated the client-side initialization to destructure `switches` from `loadConfig()` and added `addAuxSwitchCards()` which creates toggle cards via the existing `createToggleCard()` helper and registers their topics in `topics` for MQTT subscription.
- Documented the new convention in `AGENTS.md` so auxiliary switches are part of the `switches` list stored by the settings flow.

### Testing
- Performed a headless browser smoke test by serving the site locally and running a Playwright script to load `index.html` and capture a screenshot, which completed successfully. 
- No other automated test suite is configured; `npm test` was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697337a55ba0832e925d8697ad0a702f)