### PR TITLE
Add first-time config.db setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ The site depends on MQTT for live updates. The helper in `js/mqttClient.js` trea
 Connection details are stored in a SQLite `config.db` database located at `/var/www/data/config.db` outside the web root. Client-side scripts load these settings through `js/mqttConfig.js` which fetches `/get_config.php`.
 
 Use `settings.html` to edit values such as broker URL, port, username, password and dashboard topics. Changes are saved via `/save_config.php` and take effect immediately on subsequent page loads.
+
+### First-time database setup
+The application will create tables automatically the first time `/get_config.php` or `/save_config.php` is accessed, but you still need to create the directory and database file with permissions that your web server user can write to. A typical setup looks like:
+
+```bash
+sudo mkdir -p /var/www/data
+sudo touch /var/www/data/config.db
+sudo chown www-data:www-data /var/www/data/config.db
+sudo chmod 664 /var/www/data/config.db
+```
+
+After that, open `settings.html` or load `/get_config.php` once to initialize the schema.


### PR DESCRIPTION
### Motivation
- Document how to create the `/var/www/data/config.db` file and set filesystem permissions so the web server can write the SQLite database and clarify that the schema is created automatically on first access.

### Description
- Added a "First-time database setup" section to `README.md` with example commands (`sudo mkdir -p /var/www/data`, `sudo touch /var/www/data/config.db`, `sudo chown www-data:www-data /var/www/data/config.db`, `sudo chmod 664 /var/www/data/config.db`) and a note that opening `settings.html` or loading `/get_config.php` will initialize the schema.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974ce5f2d44832ea60bc793d58c856a)