### PR TITLE
Add INDI Dome scripting gateway for RoRo roof control

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Shell script defaults
+ROOF_BASE_URL=http://data.smeird.com:1880
+ROOF_HTTP_PATH=/api/roof
+
+# Node-RED flow timeouts (seconds)
+OPEN_TIMEOUT_SECS=900
+CLOSE_TIMEOUT_SECS=900
+ABORT_TIMEOUT_SECS=90
+CONNECT_TIMEOUT_SECS=5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,3 +53,4 @@
 - Interactive elements like buttons and form inputs should provide matching `dark:` variants for colors and borders.
 - Auxiliary switches on the dashboard are driven by the settings `switches` list and render in their own section below the primary roof relay switches.
 - Switch settings now include separate `commandPath` and `statusPath` topics to support multi-topic MQTT control.
+- RoRo roof controller scripts live in `scripts/roof/`, and the Node-RED flow export is stored at `nodered/flows/roof-api.json`.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,37 @@ sudo chmod 664 /var/www/data/config.db
 ```
 
 After that, open `settings.html` or load `/get_config.php` once to initialize the schema.
+
+## RoRo roof controller (INDI Dome Scripting Gateway)
+
+This repository now includes a roll-off roof controller that follows the INDI Dome Scripting Gateway pattern. Shell scripts in `scripts/roof/` call a Node-RED HTTP endpoint, which translates requests into MQTT commands and waits for state changes.
+
+### Quick start
+
+1. Import the Node-RED flow from `nodered/flows/roof-api.json` and point the MQTT broker config node at your existing broker. See `docs/nodered-deploy.md` for details.
+2. Ensure the scripts are executable:
+   ```bash
+   chmod +x scripts/roof/*.sh
+   ```
+3. Point INDI Dome Scripting Gateway at the scripts in `scripts/roof/` (see `docs/indi-dome-scripting-gateway.md`).
+
+### Environment variables
+
+Shell scripts:
+- `ROOF_BASE_URL` (default: `http://data.smeird.com:1880`)
+- `ROOF_HTTP_PATH` (default: `/api/roof`)
+- `CURL_TIMEOUT_SECS` (per-script default: status/connect/disconnect 20s, abort 90s, open/close/park/unpark 900s)
+
+Node-RED flow:
+- `OPEN_TIMEOUT_SECS=900`
+- `CLOSE_TIMEOUT_SECS=900`
+- `ABORT_TIMEOUT_SECS=90`
+- `CONNECT_TIMEOUT_SECS=5`
+
+### Curl examples
+
+```bash
+curl -fsS -H "Content-Type: application/json" -d '{"action":"status"}' http://data.smeird.com:1880/api/roof
+curl -fsS -H "Content-Type: application/json" -d '{"action":"open"}' http://data.smeird.com:1880/api/roof
+curl -fsS -H "Content-Type: application/json" -d '{"action":"close"}' http://data.smeird.com:1880/api/roof
+```

--- a/docs/indi-dome-scripting-gateway.md
+++ b/docs/indi-dome-scripting-gateway.md
@@ -1,0 +1,40 @@
+# INDI Dome Scripting Gateway (RoRo roof)
+
+This project implements the INDI Dome Scripting Gateway pattern for a roll-off roof. Point the INDI driver at the scripts in `scripts/roof/` and the driver will call shell scripts with **no arguments**.
+
+## INDI setup
+
+1. Copy the `scripts/roof/` directory to the machine running the INDI Dome Scripting Gateway.
+2. Ensure each script is executable:
+   ```bash
+   chmod +x scripts/roof/*.sh
+   ```
+3. In the INDI Dome Scripting Gateway driver, set the script paths as follows:
+   - Open: `scripts/roof/open.sh`
+   - Close: `scripts/roof/close.sh`
+   - Abort: `scripts/roof/abort.sh`
+   - Status: `scripts/roof/status.sh`
+   - Connect: `scripts/roof/connect.sh`
+   - Disconnect: `scripts/roof/disconnect.sh`
+   - Park: `scripts/roof/park.sh`
+   - Unpark: `scripts/roof/unpark.sh`
+
+## Status contract
+
+`status.sh` **prints exactly one token to stdout**:
+
+```
+OPEN | CLOSED | OPENING | CLOSING | ERROR
+```
+
+No other stdout output is produced. Any JSON response from the API that does not set `ok=true` maps to `ERROR`.
+
+## Environment variables
+
+The scripts use these environment variables (defaults shown):
+
+- `ROOF_BASE_URL` (default: `http://data.smeird.com:1880`)
+- `ROOF_HTTP_PATH` (default: `/api/roof`)
+- `CURL_TIMEOUT_SECS` (default varies by script)
+
+See the `README.md` and `.env.example` for a concise summary.

--- a/docs/nodered-deploy.md
+++ b/docs/nodered-deploy.md
@@ -1,0 +1,57 @@
+# Node-RED deployment
+
+This project provides a single HTTP endpoint (`POST /api/roof`) that translates requests into MQTT commands and waits for roof state changes.
+
+## Import the flow
+
+1. Open Node-RED and import `nodered/flows/roof-api.json`.
+2. The flow references an **existing MQTT broker configuration node** named "Existing MQTT Broker". Edit the MQTT config node to point at your broker (or map it to an existing broker node). The flow does **not** hardcode hostnames or credentials.
+3. Deploy the flow.
+
+## HTTP endpoint
+
+```
+POST /api/roof
+Content-Type: application/json
+
+{ "action": "open|close|abort|status|connect|disconnect|park|unpark" }
+```
+
+Responses are always JSON:
+
+```json
+{ "ok": true, "state": "OPEN", "message": "Open complete", "timestamp": "2024-01-01T00:00:00Z" }
+```
+
+## Environment configuration
+
+The flow reads timeouts from environment variables (defaults shown):
+
+- `OPEN_TIMEOUT_SECS=900`
+- `CLOSE_TIMEOUT_SECS=900`
+- `ABORT_TIMEOUT_SECS=90`
+- `CONNECT_TIMEOUT_SECS=5`
+
+These are loaded at startup by the "Init config" inject node.
+
+## MQTT topics
+
+Commands are published to:
+
+- `Observatory/roof-esp/command/open` (`payload: "1"`)
+- `Observatory/roof-esp/command/close` (`payload: "1"`)
+- `Observatory/roof-esp/command/stop` (`payload: "1"`)
+- `Observatory/roof-esp/command/snapshot` (`payload: "1"`)
+- `Observatory/roof-esp/command/fault_clear` (`payload: "1"`)
+
+Telemetry subscriptions include:
+
+- `Observatory/roof-esp/online`
+- `Observatory/roof-esp/open_limit`
+- `Observatory/roof-esp/close_limit`
+- `Observatory/roof-esp/moving`
+- `Observatory/roof-esp/enabled`
+- `Observatory/roof-esp/fault`
+- `Observatory/roof-esp/fault_code`
+- `Observatory/roof-esp/state/open_motor`
+- `Observatory/roof-esp/state/close_motor`

--- a/nodered/flows/roof-api.json
+++ b/nodered/flows/roof-api.json
@@ -1,0 +1,630 @@
+[
+  {
+    "id": "a2b3c4d5e6f7a8b9",
+    "type": "tab",
+    "label": "Roof API",
+    "disabled": false,
+    "info": ""
+  },
+  {
+    "id": "init-config",
+    "type": "inject",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Init config",
+    "props": [],
+    "repeat": "",
+    "crontab": "",
+    "once": true,
+    "onceDelay": 0.1,
+    "topic": "",
+    "x": 160,
+    "y": 80,
+    "wires": [
+      [
+        "load-config"
+      ]
+    ]
+  },
+  {
+    "id": "load-config",
+    "type": "function",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Load timeout config",
+    "func": "const openTimeout = Number(env.get(\"OPEN_TIMEOUT_SECS\") || 900);\nconst closeTimeout = Number(env.get(\"CLOSE_TIMEOUT_SECS\") || 900);\nconst abortTimeout = Number(env.get(\"ABORT_TIMEOUT_SECS\") || 90);\nconst connectTimeout = Number(env.get(\"CONNECT_TIMEOUT_SECS\") || 5);\n\nflow.set(\"timeout_config\", {\n    open: openTimeout,\n    close: closeTimeout,\n    abort: abortTimeout,\n    connect: connectTimeout\n});\n\nreturn null;",
+    "outputs": 0,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 390,
+    "y": 80,
+    "wires": []
+  },
+  {
+    "id": "http-in",
+    "type": "http in",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "POST /api/roof",
+    "url": "/api/roof",
+    "method": "post",
+    "upload": false,
+    "swaggerDoc": "",
+    "x": 140,
+    "y": 160,
+    "wires": [
+      [
+        "json-parse"
+      ]
+    ]
+  },
+  {
+    "id": "json-parse",
+    "type": "json",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Parse JSON",
+    "property": "payload",
+    "action": "",
+    "pretty": false,
+    "x": 320,
+    "y": 160,
+    "wires": [
+      [
+        "dispatch-action"
+      ]
+    ]
+  },
+  {
+    "id": "dispatch-action",
+    "type": "function",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Dispatch action",
+    "func": "const payload = msg.payload || {};\nconst action = payload.action;\nconst timestamp = new Date().toISOString();\nconst telemetry = flow.get(\"telemetry\") || {};\nconst derived = flow.get(\"derived_state\") || \"UNKNOWN\";\nconst lastCommand = flow.get(\"last_command\") || null;\nconst inflight = flow.get(\"inflight\");\nconst timeouts = flow.get(\"timeout_config\") || { open: 900, close: 900, abort: 90, connect: 5 };\n\nfunction response(ok, state, message) {\n    msg.payload = {\n        ok,\n        state,\n        message,\n        timestamp\n    };\n    return msg;\n}\n\nif (!action) {\n    return [response(false, derived, \"Missing action\"), null];\n}\n\nconst normalized = String(action).toLowerCase();\nconst allowed = [\"open\", \"close\", \"abort\", \"status\", \"connect\", \"disconnect\", \"park\", \"unpark\"];\nif (!allowed.includes(normalized)) {\n    return [response(false, derived, \"Unsupported action\"), null];\n}\n\nif (inflight) {\n    return [response(false, derived, \"Busy: operation in progress\"), null];\n}\n\nif (normalized === \"status\") {\n    return [response(true, derived, \"Status\"), null];\n}\n\nif (normalized === \"disconnect\") {\n    return [response(true, derived, \"Disconnect acknowledged\"), null];\n}\n\nif (normalized === \"connect\") {\n    flow.set(\"inflight\", {\n        action: \"connect\",\n        deadline: Date.now() + (timeouts.connect * 1000),\n        res: msg.res\n    });\n    const snapshotMsg = { command: \"snapshot\" };\n    const faultClearMsg = { command: \"fault_clear\" };\n    return [null, [snapshotMsg, faultClearMsg]];\n}\n\nconst openLimit = telemetry.open_limit;\nconst closeLimit = telemetry.close_limit;\nconst moving = telemetry.moving === \"1\";\n\nconst targetAction = (normalized === \"park\") ? \"close\" : (normalized === \"unpark\" ? \"open\" : normalized);\nconst targetState = targetAction === \"open\" ? \"OPEN\" : targetAction === \"close\" ? \"CLOSED\" : null;\n\nif (targetState === \"OPEN\" && derived === \"OPEN\") {\n    return [response(true, derived, \"Already open\"), null];\n}\n\nif (targetState === \"CLOSED\" && derived === \"CLOSED\") {\n    return [response(true, derived, \"Already closed\"), null];\n}\n\nif (moving) {\n    if (lastCommand === targetAction) {\n        return [response(true, derived, \"Already in progress\"), null];\n    }\n    if (lastCommand && lastCommand !== targetAction) {\n        return [response(false, derived, \"Busy: abort first\"), null];\n    }\n    return [response(false, derived, \"Busy: abort first\"), null];\n}\n\nif (normalized === \"abort\") {\n    flow.set(\"last_command\", \"abort\");\n    flow.set(\"inflight\", {\n        action: \"abort\",\n        deadline: Date.now() + (timeouts.abort * 1000),\n        res: msg.res\n    });\n    return [null, { command: \"abort\" }];\n}\n\nif (!targetState) {\n    return [response(false, derived, \"Invalid target state\"), null];\n}\n\nflow.set(\"last_command\", targetAction);\nflow.set(\"inflight\", {\n    action: targetAction,\n    targetState,\n    deadline: Date.now() + ((targetAction === \"open\" ? timeouts.open : timeouts.close) * 1000),\n    res: msg.res\n});\n\nreturn [null, { command: targetAction }];",
+    "outputs": 2,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 520,
+    "y": 160,
+    "wires": [
+      [
+        "http-response"
+      ],
+      [
+        "command-router"
+      ]
+    ]
+  },
+  {
+    "id": "command-router",
+    "type": "switch",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Command router",
+    "property": "command",
+    "propertyType": "msg",
+    "rules": [
+      {
+        "t": "eq",
+        "v": "open",
+        "vt": "str"
+      },
+      {
+        "t": "eq",
+        "v": "close",
+        "vt": "str"
+      },
+      {
+        "t": "eq",
+        "v": "abort",
+        "vt": "str"
+      },
+      {
+        "t": "eq",
+        "v": "snapshot",
+        "vt": "str"
+      },
+      {
+        "t": "eq",
+        "v": "fault_clear",
+        "vt": "str"
+      }
+    ],
+    "checkall": "true",
+    "repair": false,
+    "outputs": 5,
+    "x": 740,
+    "y": 160,
+    "wires": [
+      [
+        "set-open"
+      ],
+      [
+        "set-close"
+      ],
+      [
+        "set-abort"
+      ],
+      [
+        "set-snapshot"
+      ],
+      [
+        "set-fault-clear"
+      ]
+    ]
+  },
+  {
+    "id": "set-open",
+    "type": "change",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Set open",
+    "rules": [
+      {
+        "t": "set",
+        "p": "topic",
+        "pt": "msg",
+        "to": "Observatory/roof-esp/command/open",
+        "tot": "str"
+      },
+      {
+        "t": "set",
+        "p": "payload",
+        "pt": "msg",
+        "to": "1",
+        "tot": "str"
+      }
+    ],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 940,
+    "y": 120,
+    "wires": [
+      [
+        "mqtt-out"
+      ]
+    ]
+  },
+  {
+    "id": "set-close",
+    "type": "change",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Set close",
+    "rules": [
+      {
+        "t": "set",
+        "p": "topic",
+        "pt": "msg",
+        "to": "Observatory/roof-esp/command/close",
+        "tot": "str"
+      },
+      {
+        "t": "set",
+        "p": "payload",
+        "pt": "msg",
+        "to": "1",
+        "tot": "str"
+      }
+    ],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 940,
+    "y": 160,
+    "wires": [
+      [
+        "mqtt-out"
+      ]
+    ]
+  },
+  {
+    "id": "set-abort",
+    "type": "change",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Set abort",
+    "rules": [
+      {
+        "t": "set",
+        "p": "topic",
+        "pt": "msg",
+        "to": "Observatory/roof-esp/command/stop",
+        "tot": "str"
+      },
+      {
+        "t": "set",
+        "p": "payload",
+        "pt": "msg",
+        "to": "1",
+        "tot": "str"
+      }
+    ],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 940,
+    "y": 200,
+    "wires": [
+      [
+        "mqtt-out"
+      ]
+    ]
+  },
+  {
+    "id": "set-snapshot",
+    "type": "change",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Set snapshot",
+    "rules": [
+      {
+        "t": "set",
+        "p": "topic",
+        "pt": "msg",
+        "to": "Observatory/roof-esp/command/snapshot",
+        "tot": "str"
+      },
+      {
+        "t": "set",
+        "p": "payload",
+        "pt": "msg",
+        "to": "1",
+        "tot": "str"
+      }
+    ],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 960,
+    "y": 240,
+    "wires": [
+      [
+        "mqtt-out"
+      ]
+    ]
+  },
+  {
+    "id": "set-fault-clear",
+    "type": "change",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Set fault clear",
+    "rules": [
+      {
+        "t": "set",
+        "p": "topic",
+        "pt": "msg",
+        "to": "Observatory/roof-esp/command/fault_clear",
+        "tot": "str"
+      },
+      {
+        "t": "set",
+        "p": "payload",
+        "pt": "msg",
+        "to": "1",
+        "tot": "str"
+      }
+    ],
+    "action": "",
+    "property": "",
+    "from": "",
+    "to": "",
+    "reg": false,
+    "x": 970,
+    "y": 280,
+    "wires": [
+      [
+        "mqtt-out"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt-out",
+    "type": "mqtt out",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "MQTT command out",
+    "topic": "",
+    "qos": "0",
+    "retain": "false",
+    "respTopic": "",
+    "contentType": "",
+    "userProps": "",
+    "correl": "",
+    "expiry": "",
+    "broker": "mqtt-broker",
+    "x": 1160,
+    "y": 200,
+    "wires": []
+  },
+  {
+    "id": "mqtt-online",
+    "type": "mqtt in",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "online",
+    "topic": "Observatory/roof-esp/online",
+    "qos": "0",
+    "datatype": "utf8",
+    "broker": "mqtt-broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 140,
+    "y": 360,
+    "wires": [
+      [
+        "telemetry-update"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt-open-limit",
+    "type": "mqtt in",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "open_limit",
+    "topic": "Observatory/roof-esp/open_limit",
+    "qos": "0",
+    "datatype": "utf8",
+    "broker": "mqtt-broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 400,
+    "wires": [
+      [
+        "telemetry-update"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt-close-limit",
+    "type": "mqtt in",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "close_limit",
+    "topic": "Observatory/roof-esp/close_limit",
+    "qos": "0",
+    "datatype": "utf8",
+    "broker": "mqtt-broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 440,
+    "wires": [
+      [
+        "telemetry-update"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt-moving",
+    "type": "mqtt in",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "moving",
+    "topic": "Observatory/roof-esp/moving",
+    "qos": "0",
+    "datatype": "utf8",
+    "broker": "mqtt-broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 140,
+    "y": 480,
+    "wires": [
+      [
+        "telemetry-update"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt-enabled",
+    "type": "mqtt in",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "enabled",
+    "topic": "Observatory/roof-esp/enabled",
+    "qos": "0",
+    "datatype": "utf8",
+    "broker": "mqtt-broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 140,
+    "y": 520,
+    "wires": [
+      [
+        "telemetry-update"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt-fault",
+    "type": "mqtt in",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "fault",
+    "topic": "Observatory/roof-esp/fault",
+    "qos": "0",
+    "datatype": "utf8",
+    "broker": "mqtt-broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 130,
+    "y": 560,
+    "wires": [
+      [
+        "telemetry-update"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt-fault-code",
+    "type": "mqtt in",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "fault_code",
+    "topic": "Observatory/roof-esp/fault_code",
+    "qos": "0",
+    "datatype": "utf8",
+    "broker": "mqtt-broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 150,
+    "y": 600,
+    "wires": [
+      [
+        "telemetry-update"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt-open-motor",
+    "type": "mqtt in",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "open_motor",
+    "topic": "Observatory/roof-esp/state/open_motor",
+    "qos": "0",
+    "datatype": "utf8",
+    "broker": "mqtt-broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 170,
+    "y": 640,
+    "wires": [
+      [
+        "telemetry-update"
+      ]
+    ]
+  },
+  {
+    "id": "mqtt-close-motor",
+    "type": "mqtt in",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "close_motor",
+    "topic": "Observatory/roof-esp/state/close_motor",
+    "qos": "0",
+    "datatype": "utf8",
+    "broker": "mqtt-broker",
+    "nl": false,
+    "rap": true,
+    "rh": 0,
+    "inputs": 0,
+    "x": 170,
+    "y": 680,
+    "wires": [
+      [
+        "telemetry-update"
+      ]
+    ]
+  },
+  {
+    "id": "telemetry-update",
+    "type": "function",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Update telemetry",
+    "func": "const topicMap = {\n    \"Observatory/roof-esp/online\": \"online\",\n    \"Observatory/roof-esp/open_limit\": \"open_limit\",\n    \"Observatory/roof-esp/close_limit\": \"close_limit\",\n    \"Observatory/roof-esp/moving\": \"moving\",\n    \"Observatory/roof-esp/enabled\": \"enabled\",\n    \"Observatory/roof-esp/fault\": \"fault\",\n    \"Observatory/roof-esp/fault_code\": \"fault_code\",\n    \"Observatory/roof-esp/state/open_motor\": \"open_motor\",\n    \"Observatory/roof-esp/state/close_motor\": \"close_motor\"\n};\n\nconst key = topicMap[msg.topic];\nif (!key) {\n    return null;\n}\n\nconst telemetry = flow.get(\"telemetry\") || {};\ntelemetry[key] = String(msg.payload);\nflow.set(\"telemetry\", telemetry);\nflow.set(\"last_telemetry\", { ...telemetry });\n\nconst lastCommand = flow.get(\"last_command\") || null;\nconst derived = deriveState(telemetry, lastCommand);\nflow.set(\"derived_state\", derived);\n\nconst inflight = flow.get(\"inflight\");\nif (!inflight || !inflight.res) {\n    return null;\n}\n\nconst nowIso = new Date().toISOString();\n\nfunction respond(ok, message) {\n    flow.set(\"inflight\", null);\n    return {\n        res: inflight.res,\n        payload: {\n            ok,\n            state: derived,\n            message,\n            timestamp: nowIso\n        }\n    };\n}\n\nif (inflight.action === \"connect\") {\n    const online = telemetry.online === \"1\";\n    const limitKnown = telemetry.open_limit !== undefined || telemetry.close_limit !== undefined;\n    if (online && limitKnown) {\n        return respond(true, \"Connected\");\n    }\n    return null;\n}\n\nif (inflight.action === \"abort\") {\n    if (telemetry.moving === \"0\" && (derived === \"ABORTED\" || derived === \"UNKNOWN\")) {\n        return respond(true, \"Abort complete\");\n    }\n    return null;\n}\n\nif (inflight.targetState && derived === inflight.targetState) {\n    const message = inflight.targetState === \"OPEN\" ? \"Open complete\" : \"Close complete\";\n    return respond(true, message);\n}\n\nreturn null;\n\nfunction deriveState(telemetry, lastCommand) {\n    const online = telemetry.online;\n    const openLimit = telemetry.open_limit;\n    const closeLimit = telemetry.close_limit;\n    const moving = telemetry.moving;\n    const fault = telemetry.fault;\n    const faultCode = telemetry.fault_code;\n\n    if (online === \"0\") {\n        return \"UNKNOWN\";\n    }\n\n    if (fault === \"1\" || (faultCode && faultCode !== \"0\") || (openLimit === \"1\" && closeLimit === \"1\")) {\n        return \"FAULT\";\n    }\n\n    if (moving === \"1\") {\n        if (lastCommand === \"open\") {\n            return \"OPENING\";\n        }\n        if (lastCommand === \"close\") {\n            return \"CLOSING\";\n        }\n        return \"UNKNOWN\";\n    }\n\n    if (openLimit === \"1\" && closeLimit === \"0\") {\n        return \"OPEN\";\n    }\n\n    if (closeLimit === \"1\" && openLimit === \"0\") {\n        return \"CLOSED\";\n    }\n\n    if (lastCommand === \"abort\" && moving === \"0\" && openLimit === \"0\" && closeLimit === \"0\") {\n        return \"ABORTED\";\n    }\n\n    return \"UNKNOWN\";\n}\n",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 430,
+    "y": 520,
+    "wires": [
+      [
+        "http-response"
+      ]
+    ]
+  },
+  {
+    "id": "timeout-tick",
+    "type": "inject",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Inflight timeout tick",
+    "props": [],
+    "repeat": "1",
+    "crontab": "",
+    "once": true,
+    "onceDelay": 0.1,
+    "topic": "",
+    "x": 180,
+    "y": 740,
+    "wires": [
+      [
+        "check-timeout"
+      ]
+    ]
+  },
+  {
+    "id": "check-timeout",
+    "type": "function",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "Check inflight timeout",
+    "func": "const inflight = flow.get(\"inflight\");\nif (!inflight || !inflight.res || !inflight.deadline) {\n    return null;\n}\n\nif (Date.now() <= inflight.deadline) {\n    return null;\n}\n\nconst derived = flow.get(\"derived_state\") || \"UNKNOWN\";\nflow.set(\"inflight\", null);\n\nreturn {\n    res: inflight.res,\n    payload: {\n        ok: false,\n        state: derived,\n        message: \"Timeout waiting for operation\",\n        timestamp: new Date().toISOString()\n    }\n};",
+    "outputs": 1,
+    "noerr": 0,
+    "initialize": "",
+    "finalize": "",
+    "libs": [],
+    "x": 420,
+    "y": 740,
+    "wires": [
+      [
+        "http-response"
+      ]
+    ]
+  },
+  {
+    "id": "http-response",
+    "type": "http response",
+    "z": "a2b3c4d5e6f7a8b9",
+    "name": "HTTP response",
+    "statusCode": "",
+    "headers": {
+      "content-type": "application/json"
+    },
+    "x": 930,
+    "y": 520,
+    "wires": []
+  },
+  {
+    "id": "mqtt-broker",
+    "type": "mqtt-broker",
+    "name": "Existing MQTT Broker",
+    "broker": "",
+    "port": "1883",
+    "clientid": "",
+    "autoConnect": true,
+    "usetls": false,
+    "protocolVersion": "4",
+    "keepalive": "60",
+    "cleansession": true,
+    "autoUnsubscribe": true,
+    "birthTopic": "",
+    "birthQos": "0",
+    "birthPayload": "",
+    "birthMsg": {},
+    "closeTopic": "",
+    "closeQos": "0",
+    "closePayload": "",
+    "closeMsg": {},
+    "willTopic": "",
+    "willQos": "0",
+    "willPayload": "",
+    "willMsg": {},
+    "userProps": "",
+    "sessionExpiry": ""
+  }
+]

--- a/scripts/roof/abort.sh
+++ b/scripts/roof/abort.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
+ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-90}"
+
+response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"abort"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
+
+ok="$(printf '%s' "$response" | python3 - <<'PY'
+import json
+import sys
+try:
+    data = json.load(sys.stdin)
+    print(str(bool(data.get("ok"))).lower())
+except Exception:
+    print("false")
+PY
+)"
+
+if [[ "$ok" != "true" ]]; then
+  exit 1
+fi

--- a/scripts/roof/close.sh
+++ b/scripts/roof/close.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
+ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
+
+response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"close"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
+
+ok="$(printf '%s' "$response" | python3 - <<'PY'
+import json
+import sys
+try:
+    data = json.load(sys.stdin)
+    print(str(bool(data.get("ok"))).lower())
+except Exception:
+    print("false")
+PY
+)"
+
+if [[ "$ok" != "true" ]]; then
+  exit 1
+fi

--- a/scripts/roof/connect.sh
+++ b/scripts/roof/connect.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
+ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
+
+response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"connect"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
+
+ok="$(printf '%s' "$response" | python3 - <<'PY'
+import json
+import sys
+try:
+    data = json.load(sys.stdin)
+    print(str(bool(data.get("ok"))).lower())
+except Exception:
+    print("false")
+PY
+)"
+
+if [[ "$ok" != "true" ]]; then
+  exit 1
+fi

--- a/scripts/roof/disconnect.sh
+++ b/scripts/roof/disconnect.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
+ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
+
+response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"disconnect"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
+
+ok="$(printf '%s' "$response" | python3 - <<'PY'
+import json
+import sys
+try:
+    data = json.load(sys.stdin)
+    print(str(bool(data.get("ok"))).lower())
+except Exception:
+    print("false")
+PY
+)"
+
+if [[ "$ok" != "true" ]]; then
+  exit 1
+fi

--- a/scripts/roof/open.sh
+++ b/scripts/roof/open.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
+ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
+
+response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"open"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
+
+ok="$(printf '%s' "$response" | python3 - <<'PY'
+import json
+import sys
+try:
+    data = json.load(sys.stdin)
+    print(str(bool(data.get("ok"))).lower())
+except Exception:
+    print("false")
+PY
+)"
+
+if [[ "$ok" != "true" ]]; then
+  exit 1
+fi

--- a/scripts/roof/park.sh
+++ b/scripts/roof/park.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
+ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
+
+response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"park"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
+
+ok="$(printf '%s' "$response" | python3 - <<'PY'
+import json
+import sys
+try:
+    data = json.load(sys.stdin)
+    print(str(bool(data.get("ok"))).lower())
+except Exception:
+    print("false")
+PY
+)"
+
+if [[ "$ok" != "true" ]]; then
+  exit 1
+fi

--- a/scripts/roof/status.sh
+++ b/scripts/roof/status.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
+ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
+
+response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"status"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
+
+python3 - <<'PY' <<<"$response"
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print("ERROR")
+    sys.exit(1)
+
+ok = bool(data.get("ok"))
+state = data.get("state", "UNKNOWN")
+
+mapping = {
+    "OPEN": "OPEN",
+    "CLOSED": "CLOSED",
+    "OPENING": "OPENING",
+    "CLOSING": "CLOSING",
+    "ABORTED": "ERROR",
+    "FAULT": "ERROR",
+    "UNKNOWN": "ERROR",
+}
+
+print(mapping.get(state, "ERROR"))
+
+if not ok:
+    sys.exit(1)
+PY

--- a/scripts/roof/unpark.sh
+++ b/scripts/roof/unpark.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
+ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
+
+response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"unpark"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
+
+ok="$(printf '%s' "$response" | python3 - <<'PY'
+import json
+import sys
+try:
+    data = json.load(sys.stdin)
+    print(str(bool(data.get("ok"))).lower())
+except Exception:
+    print("false")
+PY
+)"
+
+if [[ "$ok" != "true" ]]; then
+  exit 1
+fi


### PR DESCRIPTION
### Motivation
- Provide an INDI Dome Scripting Gateway style RoRo roof controller so INDI can drive a roll-off roof using simple shell scripts that call a Node-RED HTTP gateway.
- Keep control logic outside the scripts by letting Node-RED translate requests into MQTT commands for the existing broker and maintain derived roof state and timeouts.

### Description
- Add executable shell scripts in `scripts/roof/` (`open.sh`, `close.sh`, `abort.sh`, `status.sh`, `connect.sh`, `disconnect.sh`, `park.sh`, `unpark.sh`) that `POST` JSON to `${ROOF_BASE_URL}${ROOF_HTTP_PATH}` and obey per-script `CURL_TIMEOUT_SECS` defaults.
- Provide a Node-RED flow export at `nodered/flows/roof-api.json` implementing `POST /api/roof`, mapping actions to `Observatory/roof-esp/...` MQTT topics, tracking telemetry, computing a derived state model, handling inflight synchronous waits, and enforcing configurable timeouts via environment variables.
- Add documentation in `docs/` (`indi-dome-scripting-gateway.md`, `nodered-deploy.md`), add a `.env.example` with defaults, and update `README.md` with quick-start and curl examples.
- Ensure `status.sh` prints exactly one token (`OPEN`, `CLOSED`, `OPENING`, `CLOSING`, `ERROR`) and scripts exit `0` only when the API returns `ok=true`.

### Testing
- Ran `npm test` as the repository-level automated test; it failed because no `package.json` exists in this repo (test failure is expected given the project has no npm tests configured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978dae24600832eac44033f39e3c9d5)