### PR TITLE
Refactor roof scripts JSON parsing

### DIFF
--- a/scripts/roof/abort.sh
+++ b/scripts/roof/abort.sh
@@ -7,15 +7,12 @@ CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-90}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"abort"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 - <<'PY'
-import json
-import sys
+ok="$(printf '%s' "$response" | python3 -c 'import json,sys
 try:
     data = json.load(sys.stdin)
     print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")
-PY
+    print("false")'
 )"
 
 if [[ "$ok" != "true" ]]; then

--- a/scripts/roof/close.sh
+++ b/scripts/roof/close.sh
@@ -7,15 +7,12 @@ CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"close"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 - <<'PY'
-import json
-import sys
+ok="$(printf '%s' "$response" | python3 -c 'import json,sys
 try:
     data = json.load(sys.stdin)
     print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")
-PY
+    print("false")'
 )"
 
 if [[ "$ok" != "true" ]]; then

--- a/scripts/roof/connect.sh
+++ b/scripts/roof/connect.sh
@@ -7,15 +7,12 @@ CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"connect"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 - <<'PY'
-import json
-import sys
+ok="$(printf '%s' "$response" | python3 -c 'import json,sys
 try:
     data = json.load(sys.stdin)
     print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")
-PY
+    print("false")'
 )"
 
 if [[ "$ok" != "true" ]]; then

--- a/scripts/roof/disconnect.sh
+++ b/scripts/roof/disconnect.sh
@@ -7,15 +7,12 @@ CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"disconnect"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 - <<'PY'
-import json
-import sys
+ok="$(printf '%s' "$response" | python3 -c 'import json,sys
 try:
     data = json.load(sys.stdin)
     print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")
-PY
+    print("false")'
 )"
 
 if [[ "$ok" != "true" ]]; then

--- a/scripts/roof/open.sh
+++ b/scripts/roof/open.sh
@@ -7,15 +7,12 @@ CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"open"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 - <<'PY'
-import json
-import sys
+ok="$(printf '%s' "$response" | python3 -c 'import json,sys
 try:
     data = json.load(sys.stdin)
     print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")
-PY
+    print("false")'
 )"
 
 if [[ "$ok" != "true" ]]; then

--- a/scripts/roof/park.sh
+++ b/scripts/roof/park.sh
@@ -7,15 +7,12 @@ CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"park"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 - <<'PY'
-import json
-import sys
+ok="$(printf '%s' "$response" | python3 -c 'import json,sys
 try:
     data = json.load(sys.stdin)
     print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")
-PY
+    print("false")'
 )"
 
 if [[ "$ok" != "true" ]]; then

--- a/scripts/roof/unpark.sh
+++ b/scripts/roof/unpark.sh
@@ -7,15 +7,12 @@ CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"unpark"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 - <<'PY'
-import json
-import sys
+ok="$(printf '%s' "$response" | python3 -c 'import json,sys
 try:
     data = json.load(sys.stdin)
     print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")
-PY
+    print("false")'
 )"
 
 if [[ "$ok" != "true" ]]; then


### PR DESCRIPTION
### Motivation
- Replace heredoc-based Python blocks that read JSON from stdin to avoid multiple stdin consumers and potential heredoc/stdin conflicts. 
- Ensure JSON from `curl` is consumed via a single stdin consumer and parsed with an inline `python3 -c '...'` invocation.

### Description
- Replaced heredoc Python parsing with inline `python3 -c 'import json,sys ...'` blocks in roof control scripts to read JSON from stdin. 
- Updated the following files: `scripts/roof/connect.sh`, `scripts/roof/disconnect.sh`, `scripts/roof/abort.sh`, `scripts/roof/open.sh`, `scripts/roof/close.sh`, `scripts/roof/park.sh`, and `scripts/roof/unpark.sh`.
- Preserved the existing behavior of passing the `curl` response into Python via a single pipe consumer and kept the scripts' exit logic unchanged.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c8a073680832e91d944ec77037370)