### PR TITLE
Update INDI roof scripts to satisfy gateway contract

### DIFF
--- a/scripts/roof/abort.sh
+++ b/scripts/roof/abort.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export PATH="/usr/bin:/bin"
 
+# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
-CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-90}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"abort"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 -c 'import json,sys
+ok="$(printf '%s' "${response}" | python3 - <<'PY'
+import json
+import sys
+
 try:
     data = json.load(sys.stdin)
-    print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")'
+    print("false")
+    sys.exit(0)
+
+print("true" if data.get("ok") is True else "false")
+PY
 )"
 
-if [[ "$ok" != "true" ]]; then
+if [[ "${ok}" != "true" ]]; then
   exit 1
 fi

--- a/scripts/roof/close.sh
+++ b/scripts/roof/close.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export PATH="/usr/bin:/bin"
 
+# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
-CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"close"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 -c 'import json,sys
+ok="$(printf '%s' "${response}" | python3 - <<'PY'
+import json
+import sys
+
 try:
     data = json.load(sys.stdin)
-    print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")'
+    print("false")
+    sys.exit(0)
+
+print("true" if data.get("ok") is True else "false")
+PY
 )"
 
-if [[ "$ok" != "true" ]]; then
+if [[ "${ok}" != "true" ]]; then
   exit 1
 fi

--- a/scripts/roof/connect.sh
+++ b/scripts/roof/connect.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export PATH="/usr/bin:/bin"
 
+# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"connect"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 -c 'import json,sys
+ok="$(printf '%s' "${response}" | python3 - <<'PY'
+import json
+import sys
+
 try:
     data = json.load(sys.stdin)
-    print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")'
+    print("false")
+    sys.exit(0)
+
+print("true" if data.get("ok") is True else "false")
+PY
 )"
 
-if [[ "$ok" != "true" ]]; then
+if [[ "${ok}" != "true" ]]; then
   exit 1
 fi

--- a/scripts/roof/disconnect.sh
+++ b/scripts/roof/disconnect.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export PATH="/usr/bin:/bin"
 
+# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"disconnect"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 -c 'import json,sys
+ok="$(printf '%s' "${response}" | python3 - <<'PY'
+import json
+import sys
+
 try:
     data = json.load(sys.stdin)
-    print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")'
+    print("false")
+    sys.exit(0)
+
+print("true" if data.get("ok") is True else "false")
+PY
 )"
 
-if [[ "$ok" != "true" ]]; then
+if [[ "${ok}" != "true" ]]; then
   exit 1
 fi

--- a/scripts/roof/open.sh
+++ b/scripts/roof/open.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export PATH="/usr/bin:/bin"
 
+# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
-CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"open"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 -c 'import json,sys
+ok="$(printf '%s' "${response}" | python3 - <<'PY'
+import json
+import sys
+
 try:
     data = json.load(sys.stdin)
-    print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")'
+    print("false")
+    sys.exit(0)
+
+print("true" if data.get("ok") is True else "false")
+PY
 )"
 
-if [[ "$ok" != "true" ]]; then
+if [[ "${ok}" != "true" ]]; then
   exit 1
 fi

--- a/scripts/roof/park.sh
+++ b/scripts/roof/park.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export PATH="/usr/bin:/bin"
 
+# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
-CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"park"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 -c 'import json,sys
+ok="$(printf '%s' "${response}" | python3 - <<'PY'
+import json
+import sys
+
 try:
     data = json.load(sys.stdin)
-    print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")'
+    print("false")
+    sys.exit(0)
+
+print("true" if data.get("ok") is True else "false")
+PY
 )"
 
-if [[ "$ok" != "true" ]]; then
+if [[ "${ok}" != "true" ]]; then
   exit 1
 fi

--- a/scripts/roof/status.sh
+++ b/scripts/roof/status.sh
@@ -1,42 +1,48 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export PATH="/usr/bin:/bin"
 
+# INDI Dome Scripting Gateway: write "<parked> <shutter> <az>" to argv[1] on success.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-# Fetch status JSON
-response="$(
-  curl -fsS --max-time "${CURL_TIMEOUT_SECS}" \
-    -H "Content-Type: application/json" \
-    -d '{"action":"status"}' \
-    "${ROOF_BASE_URL}${ROOF_HTTP_PATH}"
+status_file="${1:?Missing status file path}"
+
+response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"status"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
+
+parsed="$(printf '%s' "${response}" | python3 - <<'PY'
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print("false\tUNKNOWN")
+    sys.exit(0)
+
+ok = data.get("ok") is True
+state = data.get("state") or "UNKNOWN"
+print("true" if ok else "false", state, sep="\t")
+PY
 )"
 
-# Parse JSON safely without stdin conflicts
-python3 -c '
-import json, sys
+ok="${parsed%%$'\t'*}"
+state="${parsed#*$'\t'}"
 
-s = sys.argv[1]
-try:
-    data = json.loads(s)
-except Exception:
-    print("ERROR")
-    sys.exit(1)
+if [[ "${ok}" != "true" ]]; then
+  exit 1
+fi
 
-ok = bool(data.get("ok"))
-state = (data.get("state") or "UNKNOWN").upper()
+parked=0
+shutter=0
+case "${state}" in
+  CLOSED)
+    parked=1
+    ;;
+  OPEN)
+    shutter=1
+    ;;
+esac
 
-mapping = {
-    "OPEN": "OPEN",
-    "CLOSED": "CLOSED",
-    "OPENING": "OPENING",
-    "CLOSING": "CLOSING",
-    "ABORTED": "ERROR",
-    "FAULT": "ERROR",
-    "UNKNOWN": "ERROR",
-}
-
-print(mapping.get(state, "ERROR"))
-sys.exit(0 if ok else 1)
-' "$response"
+printf '%d %d 0.0\n' "${parked}" "${shutter}" > "${status_file}"

--- a/scripts/roof/unpark.sh
+++ b/scripts/roof/unpark.sh
@@ -1,20 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export PATH="/usr/bin:/bin"
 
+# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
-CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-900}"
+CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"unpark"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
 
-ok="$(printf '%s' "$response" | python3 -c 'import json,sys
+ok="$(printf '%s' "${response}" | python3 - <<'PY'
+import json
+import sys
+
 try:
     data = json.load(sys.stdin)
-    print(str(bool(data.get("ok"))).lower())
 except Exception:
-    print("false")'
+    print("false")
+    sys.exit(0)
+
+print("true" if data.get("ok") is True else "false")
+PY
 )"
 
-if [[ "$ok" != "true" ]]; then
+if [[ "${ok}" != "true" ]]; then
   exit 1
 fi


### PR DESCRIPTION
### Motivation
- Standardize roof control scripts so they run reliably under minimal environments and follow the INDI Dome Scripting Gateway expectations. 
- Ensure robust JSON handling and deterministic exit codes so the driver can interpret success/failure from the API `ok` field. 
- Implement the strict STATUS contract so INDI can parse the required `parked shutter az` tuple from a temp file. 

### Description
- Added explicit `export PATH="/usr/bin:/bin"`, strict `set -euo pipefail`, and small header comments to each script in `scripts/roof/`. 
- Consolidated overridable env vars `ROOF_BASE_URL`, `ROOF_HTTP_PATH`, and `CURL_TIMEOUT_SECS` (default `20`) and call the API using `curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"..."}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}"`. 
- Replaced brittle `python3 -c` parsing with a safe `python3` heredoc that reads JSON from stdin and prints a normalized `true/false` `ok` value; scripts exit `0` only when `ok==true`. 
- Implemented `status.sh` to accept the required status-file argument and write exactly `"<parked> <shutter> 0.0\n"` where `parked=1` for `CLOSED`, `shutter=1` for `OPEN`, and the script exits `0` only when the API returned `ok==true`. 

### Testing
- Ran `npm test` to check repository tests and it failed because no `package.json` is present, so there are no configured automated tests. 
- No other automated test suites were available or executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c9b4c45ac832e92de9693115beb91)