### PR TITLE
Stream JSON parsing in INDI roof scripts

### DIFF
--- a/scripts/roof/abort.sh
+++ b/scripts/roof/abort.sh
@@ -7,16 +7,12 @@ ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"abort"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
-
-ok="$(python3 -c 'import json, sys
+if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"abort"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
 try:
-    data = json.loads(sys.argv[1])
+    data = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
-print("true" if data.get("ok") is True else "false")
-' "${response}")"
-
-if [[ "${ok}" != "true" ]]; then
+sys.exit(0 if data.get("ok") is True else 1)
+'; then
   exit 1
 fi

--- a/scripts/roof/close.sh
+++ b/scripts/roof/close.sh
@@ -7,16 +7,12 @@ ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"close"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
-
-ok="$(python3 -c 'import json, sys
+if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"close"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
 try:
-    data = json.loads(sys.argv[1])
+    data = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
-print("true" if data.get("ok") is True else "false")
-' "${response}")"
-
-if [[ "${ok}" != "true" ]]; then
+sys.exit(0 if data.get("ok") is True else 1)
+'; then
   exit 1
 fi

--- a/scripts/roof/connect.sh
+++ b/scripts/roof/connect.sh
@@ -7,16 +7,12 @@ ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"connect"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
-
-ok="$(python3 -c 'import json, sys
+if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"connect"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
 try:
-    data = json.loads(sys.argv[1])
+    data = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
-print("true" if data.get("ok") is True else "false")
-' "${response}")"
-
-if [[ "${ok}" != "true" ]]; then
+sys.exit(0 if data.get("ok") is True else 1)
+'; then
   exit 1
 fi

--- a/scripts/roof/disconnect.sh
+++ b/scripts/roof/disconnect.sh
@@ -7,16 +7,12 @@ ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"disconnect"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
-
-ok="$(python3 -c 'import json, sys
+if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"disconnect"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
 try:
-    data = json.loads(sys.argv[1])
+    data = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
-print("true" if data.get("ok") is True else "false")
-' "${response}")"
-
-if [[ "${ok}" != "true" ]]; then
+sys.exit(0 if data.get("ok") is True else 1)
+'; then
   exit 1
 fi

--- a/scripts/roof/open.sh
+++ b/scripts/roof/open.sh
@@ -7,16 +7,12 @@ ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"open"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
-
-ok="$(python3 -c 'import json, sys
+if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"open"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
 try:
-    data = json.loads(sys.argv[1])
+    data = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
-print("true" if data.get("ok") is True else "false")
-' "${response}")"
-
-if [[ "${ok}" != "true" ]]; then
+sys.exit(0 if data.get("ok") is True else 1)
+'; then
   exit 1
 fi

--- a/scripts/roof/park.sh
+++ b/scripts/roof/park.sh
@@ -7,16 +7,12 @@ ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"park"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
-
-ok="$(python3 -c 'import json, sys
+if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"park"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
 try:
-    data = json.loads(sys.argv[1])
+    data = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
-print("true" if data.get("ok") is True else "false")
-' "${response}")"
-
-if [[ "${ok}" != "true" ]]; then
+sys.exit(0 if data.get("ok") is True else 1)
+'; then
   exit 1
 fi

--- a/scripts/roof/status.sh
+++ b/scripts/roof/status.sh
@@ -9,11 +9,9 @@ CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 status_file="${1:?Missing status file path}"
 
-response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"status"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
-
-status_line="$(python3 -c 'import json, sys
+if ! status_line="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"status"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
 try:
-    data = json.loads(sys.argv[1])
+    data = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
 if data.get("ok") is not True:
@@ -27,6 +25,8 @@ try:
 except Exception:
     az = 0.0
 print(f"{parked} {shutter} {az}")
-' "${response}")"
+')"; then
+  exit 1
+fi
 
 printf '%s\n' "${status_line}" > "${status_file}"

--- a/scripts/roof/unpark.sh
+++ b/scripts/roof/unpark.sh
@@ -7,16 +7,12 @@ ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-response="$(curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"unpark"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}")"
-
-ok="$(python3 -c 'import json, sys
+if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"unpark"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
 try:
-    data = json.loads(sys.argv[1])
+    data = json.load(sys.stdin)
 except Exception:
     sys.exit(1)
-print("true" if data.get("ok") is True else "false")
-' "${response}")"
-
-if [[ "${ok}" != "true" ]]; then
+sys.exit(0 if data.get("ok") is True else 1)
+'; then
   exit 1
 fi


### PR DESCRIPTION
### Motivation
- Fix incorrect exit handling where shell scripts parsed API tokens as arguments and could return the wrong exit code, and ensure the status file is only written when the API response is valid.
- Ensure the scripts parse the Roof API JSON `ok` boolean and state fields consistently with the Node-RED `roof-api` flow so automation and INDI clients receive reliable exit behavior.

### Description
- Stream `curl` output into Python across the action scripts and use `json.load(sys.stdin)` with `sys.exit(0 if data.get("ok") is True else 1)` in `scripts/roof/{abort,close,connect,disconnect,open,park,unpark}.sh` so shell exits match the API `ok` boolean.
- Update `scripts/roof/status.sh` to parse streamed JSON, verify `ok` is true, compute the `<parked> <shutter> <az>` status line from `state`/`az`, and fail before writing the status file on parse or `ok` failures.
- Reviewed the Node-RED flow `nodered/flows/roof-api.json` to confirm the flow returns the `{ok, state, az, ...}` payload shape expected by the new parsing logic.

### Testing
- No automated tests were configured or run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cefa0bb90832ea76e19df7099c3ed)