### PR TITLE
Simplify roof command scripts to exit after sending command

### DIFF
--- a/scripts/roof/abort.sh
+++ b/scripts/roof/abort.sh
@@ -2,17 +2,11 @@
 set -euo pipefail
 export PATH="/usr/bin:/bin"
 
-# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
+# INDI Dome Scripting Gateway: exit 0 once the command request is sent.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"abort"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(1)
-sys.exit(0 if data.get("ok") is True else 1)
-'; then
+if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"abort"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" > /dev/null; then
   exit 1
 fi

--- a/scripts/roof/close.sh
+++ b/scripts/roof/close.sh
@@ -2,17 +2,11 @@
 set -euo pipefail
 export PATH="/usr/bin:/bin"
 
-# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
+# INDI Dome Scripting Gateway: exit 0 once the command request is sent.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"close"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(1)
-sys.exit(0 if data.get("ok") is True else 1)
-'; then
+if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"close"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" > /dev/null; then
   exit 1
 fi

--- a/scripts/roof/open.sh
+++ b/scripts/roof/open.sh
@@ -2,17 +2,11 @@
 set -euo pipefail
 export PATH="/usr/bin:/bin"
 
-# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
+# INDI Dome Scripting Gateway: exit 0 once the command request is sent.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"open"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(1)
-sys.exit(0 if data.get("ok") is True else 1)
-'; then
+if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"open"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" > /dev/null; then
   exit 1
 fi


### PR DESCRIPTION
### Motivation
- The abort/open/close scripts should fire the roof API command and return immediately so `status.sh` can poll and determine progress instead of blocking while parsing the API response.

### Description
- Updated `scripts/roof/abort.sh`, `scripts/roof/open.sh`, and `scripts/roof/close.sh` to stop parsing JSON responses and instead issue the `curl` request and discard the response (`> /dev/null`), exiting 0 once the request is sent.

### Testing
- No automated tests were run; the project has no relevant automated tests configured and tests requiring the database were intentionally avoided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf3ad037c832eb8c572eafef06933)