### PR TITLE
Display fault code descriptions in roof status

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,6 +286,11 @@ try {
 }
 
 const roofEspBase = 'Observatory/roof-esp';
+const faultCodeLabels = {
+  BOTH_LIMITS: 'Fault: Both limit switches active',
+  TIMEOUT_OPEN: 'Fault: Open timeout exceeded',
+  TIMEOUT_CLOSE: 'Fault: Close timeout exceeded'
+};
 const roofEsp = {
   state: {
     online: `${roofEspBase}/online`,
@@ -927,7 +932,13 @@ function updateStatusValue(topic, value) {
     text = value === '1' ? 'Fault' : 'OK';
     tone = value === '1' ? 'bad' : 'good';
   } else if (topic === roofEsp.state.faultCode) {
-    text = value;
+    if (!value || value === '0') {
+      text = 'No fault';
+      tone = 'good';
+    } else {
+      text = faultCodeLabels[value] || `Fault: ${value}`;
+      tone = 'bad';
+    }
   } else if (topic === roofEsp.state.heartbeat) {
     updateHeartbeatDisplay();
     updateRoofCardBorder();


### PR DESCRIPTION
### Motivation
- Replace raw fault codes in the roof status panel with human-readable messages so the UI shows which specific fault occurred instead of an opaque code.

### Description
- Add a `faultCodeLabels` mapping and update `updateStatusValue` to display `No fault` for `0`, map known codes to descriptive strings, fall back to `Fault: <code>` for unknown codes, and update the displayed tone (`good`/`bad`) accordingly.

### Testing
- Launched a local `python -m http.server` and rendered `index.html` with Playwright to visually verify the fault label change (screenshot artifact produced); no automated unit tests are configured so `npm test` was not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697df1e0e7d0832e813fa95bf091977a)