### PR TITLE
Make roof scripts fire-and-forget

### DIFF
--- a/scripts/roof/abort.sh
+++ b/scripts/roof/abort.sh
@@ -9,3 +9,4 @@ CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"abort"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" > /dev/null 2>&1 &
 disown
+exit 0

--- a/scripts/roof/close.sh
+++ b/scripts/roof/close.sh
@@ -9,3 +9,4 @@ CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"close"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" > /dev/null 2>&1 &
 disown
+exit 0

--- a/scripts/roof/open.sh
+++ b/scripts/roof/open.sh
@@ -9,3 +9,4 @@ CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
 curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"open"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" > /dev/null 2>&1 &
 disown
+exit 0

--- a/scripts/roof/park.sh
+++ b/scripts/roof/park.sh
@@ -2,17 +2,11 @@
 set -euo pipefail
 export PATH="/usr/bin:/bin"
 
-# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
+# INDI Dome Scripting Gateway: exit 0 once the command request is sent.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"park"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(1)
-sys.exit(0 if data.get("ok") is True else 1)
-'; then
-  exit 1
-fi
+curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"park"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" > /dev/null 2>&1 &
+disown
+exit 0

--- a/scripts/roof/unpark.sh
+++ b/scripts/roof/unpark.sh
@@ -2,17 +2,11 @@
 set -euo pipefail
 export PATH="/usr/bin:/bin"
 
-# INDI Dome Scripting Gateway: exits 0 only when the roof API returns ok=true.
+# INDI Dome Scripting Gateway: exit 0 once the command request is sent.
 ROOF_BASE_URL="${ROOF_BASE_URL:-http://data.smeird.com:1880}"
 ROOF_HTTP_PATH="${ROOF_HTTP_PATH:-/api/roof}"
 CURL_TIMEOUT_SECS="${CURL_TIMEOUT_SECS:-20}"
 
-if ! curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"unpark"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" | python3 -c 'import json, sys
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(1)
-sys.exit(0 if data.get("ok") is True else 1)
-'; then
-  exit 1
-fi
+curl -fsS --max-time "${CURL_TIMEOUT_SECS}" -H "Content-Type: application/json" -d '{"action":"unpark"}' "${ROOF_BASE_URL}${ROOF_HTTP_PATH}" > /dev/null 2>&1 &
+disown
+exit 0


### PR DESCRIPTION
### Motivation
- The roof control scripts should initiate the requested action but not block while waiting for completion, and they must exit with a success status so callers can proceed immediately.

### Description
- Updated `scripts/roof/open.sh`, `scripts/roof/close.sh`, and `scripts/roof/abort.sh` to dispatch the `curl` request in the background, call `disown`, and `exit 0` after sending the request.
- Replaced the synchronous JSON-response check in `scripts/roof/park.sh` and `scripts/roof/unpark.sh` with the same background-dispatch pattern to make their behavior consistent with the other action scripts.
- Adjusted header comments in `park.sh` and `unpark.sh` to reflect the new fire-and-forget semantics.

### Testing
- No automated tests were executed because the repository does not have an automated test suite configured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697df973ef98832ea92198c9383f7685)