### PR TITLE
Clarify INDI dome scripting status contract

### DIFF
--- a/docs/indi-dome-scripting-gateway.md
+++ b/docs/indi-dome-scripting-gateway.md
@@ -1,6 +1,6 @@
 # INDI Dome Scripting Gateway (RoRo roof)
 
-This project implements the INDI Dome Scripting Gateway pattern for a roll-off roof. Point the INDI driver at the scripts in `scripts/roof/` and the driver will call shell scripts with **no arguments**.
+This project implements the INDI Dome Scripting Gateway pattern for a roll-off roof. Point the INDI driver at the scripts in `scripts/roof/` and the driver will call the shell scripts with **no arguments** (except for `status.sh`, which receives a temporary status file path as its first argument).
 
 ## INDI setup
 
@@ -21,13 +21,17 @@ This project implements the INDI Dome Scripting Gateway pattern for a roll-off r
 
 ## Status contract
 
-`status.sh` **prints exactly one token to stdout**:
+The INDI driver expects the status script to **write a single line to the status file path passed as argument 1**. The format is:
 
 ```
-OPEN | CLOSED | OPENING | CLOSING | ERROR
+<parked> <shutter> <az>
 ```
 
-No other stdout output is produced. Any JSON response from the API that does not set `ok=true` maps to `ERROR`.
+- `parked`: `1` when the roof is parked/closed, otherwise `0`.
+- `shutter`: `1` when the roof is open, otherwise `0`.
+- `az`: a floating-point azimuth value (use `0` for roll-off roofs).
+
+The script should exit non-zero if it cannot produce a valid line.
 
 ## Environment variables
 


### PR DESCRIPTION
### Motivation
- Make the documentation match the INDI Dome Scripting Gateway driver's runtime behavior by clarifying that only the status script receives an argument and describing the exact status format the driver expects.
- Ensure operators and integrators understand the `status.sh` output so the C driver can parse parked/shutter/az values correctly for roll-off roofs.

### Description
- Updated `docs/indi-dome-scripting-gateway.md` to state that `status.sh` receives a temporary status file path as its first argument and must write a single line in the format `<parked> <shutter> <az>` to that file.
- Documented the semantics of the three fields (`parked`, `shutter`, `az`) and that the script should exit non-zero if it cannot produce a valid line.
- Verified that the repository's `scripts/roof/status.sh` implements writing `"<parked> <shutter> <az>"` to the provided file and that other `scripts/roof/*.sh` scripts are invoked with no arguments and operate in a fire-and-forget manner.

### Testing
- Ran `npm test` which failed due to a missing `package.json` in the repository (no other automated test suite is configured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697dfc55f190832eb5fda737df4152a3)