### PR TITLE
Add Hue MQTT command/status Node-RED flows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,3 +55,4 @@
 - Switch settings now include separate `commandPath` and `statusPath` topics to support multi-topic MQTT control.
 - RoRo roof controller scripts live in `scripts/roof/`, and the Node-RED flow export is stored at `nodered/flows/roof-api.json`.
 - The roof API accepts a `fault_clear` action; the disconnect script triggers it after disconnect.
+- Hue devices in Node-RED publish to MQTT status topics under `Observatory/hue/<device>/status` and accept commands at `Observatory/hue/<device>/command`.

--- a/nodered/flows/roof-api.json
+++ b/nodered/flows/roof-api.json
@@ -617,5 +617,250 @@
         "willMsg": {},
         "userProps": "",
         "sessionExpiry": ""
+    },
+    {
+        "id": "3fa71478fa45bc6c",
+        "type": "tab",
+        "label": "Hue MQTT",
+        "disabled": false,
+        "info": "Hue devices bridged to MQTT with command/status topics."
+    },
+    {
+        "id": "d3bfd55ffa75b7a9",
+        "type": "hue-motion",
+        "z": "3fa71478fa45bc6c",
+        "name": "Patio Sensor",
+        "bridge": "bdad3840753f2856",
+        "sensorid": "10",
+        "x": 360,
+        "y": 140,
+        "wires": [
+            [
+                "6c8f45f1f83a0df1"
+            ]
+        ]
+    },
+    {
+        "id": "0231ea569f2e33b3",
+        "type": "hue-motion",
+        "z": "3fa71478fa45bc6c",
+        "name": "Observatory Sensor",
+        "bridge": "bdad3840753f2856",
+        "sensorid": "15",
+        "x": 380,
+        "y": 200,
+        "wires": [
+            [
+                "d3194f02ed09d6be"
+            ]
+        ]
+    },
+    {
+        "id": "a77be0dfd05084cd",
+        "type": "hue-light",
+        "z": "3fa71478fa45bc6c",
+        "name": "veg flood",
+        "bridge": "bdad3840753f2856",
+        "lightid": "15",
+        "colornamer": true,
+        "x": 350,
+        "y": 360,
+        "wires": [
+            [
+                "1b78430d4bcb0a73"
+            ]
+        ]
+    },
+    {
+        "id": "8232f0dd95a1709e",
+        "type": "hue-group",
+        "z": "3fa71478fa45bc6c",
+        "name": "Patio",
+        "bridge": "bdad3840753f2856",
+        "groupid": "2",
+        "colornamer": true,
+        "x": 330,
+        "y": 520,
+        "wires": [
+            [
+                "2d3d7b50ef52fd2e"
+            ]
+        ]
+    },
+    {
+        "id": "bdad3840753f2856",
+        "type": "hue-bridge",
+        "name": "Lights 2",
+        "bridge": "10.0.179.139",
+        "key": "ZS2Jgf0BRo2d-sGJ3T1y7lcKhugPCN0782jj9JYv",
+        "interval": "3000"
+    },
+    {
+        "id": "ddc9615ba5b6b4cd",
+        "type": "mqtt in",
+        "z": "3fa71478fa45bc6c",
+        "name": "Veg flood command",
+        "topic": "Observatory/hue/veg_flood/command",
+        "qos": "0",
+        "datatype": "json",
+        "broker": "794f28c59fcb0eca",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 120,
+        "y": 360,
+        "wires": [
+            [
+                "a77be0dfd05084cd"
+            ]
+        ]
+    },
+    {
+        "id": "3b38977ad4d0dbb0",
+        "type": "mqtt in",
+        "z": "3fa71478fa45bc6c",
+        "name": "Patio command",
+        "topic": "Observatory/hue/patio/command",
+        "qos": "0",
+        "datatype": "json",
+        "broker": "794f28c59fcb0eca",
+        "nl": false,
+        "rap": true,
+        "rh": 0,
+        "inputs": 0,
+        "x": 120,
+        "y": 520,
+        "wires": [
+            [
+                "8232f0dd95a1709e"
+            ]
+        ]
+    },
+    {
+        "id": "6c8f45f1f83a0df1",
+        "type": "change",
+        "z": "3fa71478fa45bc6c",
+        "name": "Patio sensor status topic",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "Observatory/hue/patio_sensor/status",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 640,
+        "y": 140,
+        "wires": [
+            [
+                "7a72e2288b54cc0f"
+            ]
+        ]
+    },
+    {
+        "id": "d3194f02ed09d6be",
+        "type": "change",
+        "z": "3fa71478fa45bc6c",
+        "name": "Observatory sensor status topic",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "Observatory/hue/observatory_sensor/status",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 680,
+        "y": 200,
+        "wires": [
+            [
+                "7a72e2288b54cc0f"
+            ]
+        ]
+    },
+    {
+        "id": "1b78430d4bcb0a73",
+        "type": "change",
+        "z": "3fa71478fa45bc6c",
+        "name": "Veg flood status topic",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "Observatory/hue/veg_flood/status",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 620,
+        "y": 360,
+        "wires": [
+            [
+                "7a72e2288b54cc0f"
+            ]
+        ]
+    },
+    {
+        "id": "2d3d7b50ef52fd2e",
+        "type": "change",
+        "z": "3fa71478fa45bc6c",
+        "name": "Patio status topic",
+        "rules": [
+            {
+                "t": "set",
+                "p": "topic",
+                "pt": "msg",
+                "to": "Observatory/hue/patio/status",
+                "tot": "str"
+            }
+        ],
+        "action": "",
+        "property": "",
+        "from": "",
+        "to": "",
+        "reg": false,
+        "x": 610,
+        "y": 520,
+        "wires": [
+            [
+                "7a72e2288b54cc0f"
+            ]
+        ]
+    },
+    {
+        "id": "7a72e2288b54cc0f",
+        "type": "mqtt out",
+        "z": "3fa71478fa45bc6c",
+        "name": "MQTT status out",
+        "topic": "",
+        "qos": "0",
+        "retain": "false",
+        "respTopic": "",
+        "contentType": "",
+        "userProps": "",
+        "correl": "",
+        "expiry": "",
+        "broker": "794f28c59fcb0eca",
+        "x": 890,
+        "y": 320,
+        "wires": []
     }
 ]


### PR DESCRIPTION
### Motivation
- Provide a Node-RED integration so the Hue motion sensors and lights publish status and accept commands over MQTT using a command/status topic pattern.
- Keep the project documentation up to date with the chosen MQTT topic convention for Hue devices.

### Description
- Add a new Node-RED tab `Hue MQTT` inside `nodered/flows/roof-api.json` that contains the two `hue-motion`, one `hue-light`, and one `hue-group` nodes wired to MQTT command inputs and status outputs.
- Add `mqtt in` nodes subscribing to `Observatory/hue/<device>/command` and route payloads into the Hue nodes, and add `change` nodes that set `msg.topic` to `Observatory/hue/<device>/status` and forward device state to an `mqtt out` node.
- Reuse the existing MQTT broker node defined in the flow (`homeassistant.smeird.com`) so the new tab connects to the same broker instance.
- Document the convention in `AGENTS.md` that Hue devices publish status under `Observatory/hue/<device>/status` and accept commands at `Observatory/hue/<device>/command`.

### Testing
- No automated tests were run because none are configured for these flow changes, and DB-dependent tests were intentionally avoided per instructions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1bda3d04832ea2f0284611f308dc)