### PR TITLE
Support dual command topics for auxiliary switches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,3 +56,4 @@
 - RoRo roof controller scripts live in `scripts/roof/`, and the Node-RED flow export is stored at `nodered/flows/roof-api.json`.
 - The roof API accepts a `fault_clear` action; the disconnect script triggers it after disconnect.
 - Hue devices in Node-RED publish to MQTT status topics under `Observatory/hue/<device>/status` and accept commands at `Observatory/hue/<device>/command`.
+- Auxiliary switches now support distinct command-on and command-off MQTT topics alongside a status topic.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,4 +56,4 @@
 - RoRo roof controller scripts live in `scripts/roof/`, and the Node-RED flow export is stored at `nodered/flows/roof-api.json`.
 - The roof API accepts a `fault_clear` action; the disconnect script triggers it after disconnect.
 - Hue devices in Node-RED publish to MQTT status topics under `Observatory/hue/<device>/status` and accept commands at `Observatory/hue/<device>/command`.
-- Auxiliary switches now support distinct command-on and command-off MQTT topics alongside a status topic.
+- Auxiliary switches use a single command topic (1/0 payloads) alongside a status topic (1/0).

--- a/config.php
+++ b/config.php
@@ -35,12 +35,10 @@ function getDb() {
     if (!$hasField) {
         $db->exec('ALTER TABLE sensors ADD COLUMN influx_field TEXT');
     }
-    $db->exec('CREATE TABLE IF NOT EXISTS switches (id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT UNIQUE, name TEXT, command_path TEXT, status_path TEXT, command_on_path TEXT, command_off_path TEXT)');
+    $db->exec('CREATE TABLE IF NOT EXISTS switches (id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT UNIQUE, name TEXT, command_path TEXT, status_path TEXT)');
     $switchCols = $db->query('PRAGMA table_info(switches)');
     $hasCommandPath = false;
     $hasStatusPath = false;
-    $hasCommandOnPath = false;
-    $hasCommandOffPath = false;
     while ($col = $switchCols->fetchArray(SQLITE3_ASSOC)) {
         if ($col['name'] === 'command_path') {
             $hasCommandPath = true;
@@ -48,24 +46,12 @@ function getDb() {
         if ($col['name'] === 'status_path') {
             $hasStatusPath = true;
         }
-        if ($col['name'] === 'command_on_path') {
-            $hasCommandOnPath = true;
-        }
-        if ($col['name'] === 'command_off_path') {
-            $hasCommandOffPath = true;
-        }
     }
     if (!$hasCommandPath) {
         $db->exec('ALTER TABLE switches ADD COLUMN command_path TEXT');
     }
     if (!$hasStatusPath) {
         $db->exec('ALTER TABLE switches ADD COLUMN status_path TEXT');
-    }
-    if (!$hasCommandOnPath) {
-        $db->exec('ALTER TABLE switches ADD COLUMN command_on_path TEXT');
-    }
-    if (!$hasCommandOffPath) {
-        $db->exec('ALTER TABLE switches ADD COLUMN command_off_path TEXT');
     }
     $db->exec('CREATE TABLE IF NOT EXISTS roof (id INTEGER PRIMARY KEY CHECK (id = 1), open_path TEXT, open_limit TEXT, close_path TEXT, close_limit TEXT)');
     return $db;
@@ -134,19 +120,15 @@ function replaceSensors($sensors) {
 
 function getSwitches() {
     $db = getDb();
-    $res = $db->query('SELECT path, name, command_path, status_path, command_on_path, command_off_path FROM switches ORDER BY id');
+    $res = $db->query('SELECT path, name, command_path, status_path FROM switches ORDER BY id');
     $switches = [];
     while ($row = $res->fetchArray(SQLITE3_ASSOC)) {
         $commandPath = $row['command_path'] ?? '';
         $statusPath = $row['status_path'] ?? '';
-        $commandOnPath = $row['command_on_path'] ?? '';
-        $commandOffPath = $row['command_off_path'] ?? '';
         $fallback = $row['path'] ?? '';
         $row['commandPath'] = $commandPath !== '' ? $commandPath : $fallback;
-        $row['commandOnPath'] = $commandOnPath !== '' ? $commandOnPath : ($commandPath !== '' ? $commandPath : $fallback);
-        $row['commandOffPath'] = $commandOffPath !== '' ? $commandOffPath : ($commandPath !== '' ? $commandPath : $fallback);
         $row['statusPath'] = $statusPath !== '' ? $statusPath : $fallback;
-        unset($row['command_path'], $row['status_path'], $row['command_on_path'], $row['command_off_path']);
+        unset($row['command_path'], $row['status_path']);
         $switches[] = $row;
     }
     return $switches;
@@ -155,20 +137,16 @@ function getSwitches() {
 function replaceSwitches($switches) {
     $db = getDb();
     $db->exec('DELETE FROM switches');
-    $stmt = $db->prepare('INSERT INTO switches (path, name, command_path, status_path, command_on_path, command_off_path) VALUES (:path, :name, :command_path, :status_path, :command_on_path, :command_off_path)');
+    $stmt = $db->prepare('INSERT INTO switches (path, name, command_path, status_path) VALUES (:path, :name, :command_path, :status_path)');
     foreach ($switches as $sw) {
-        $path = $sw['path'] ?? $sw['commandOnPath'] ?? $sw['commandOffPath'] ?? $sw['commandPath'] ?? $sw['statusPath'] ?? '';
+        $path = $sw['path'] ?? $sw['commandPath'] ?? $sw['statusPath'] ?? '';
         if ($path === '') continue;
         $commandPath = $sw['commandPath'] ?? $path;
-        $commandOnPath = $sw['commandOnPath'] ?? $commandPath ?? $path;
-        $commandOffPath = $sw['commandOffPath'] ?? $commandPath ?? $path;
         $statusPath = $sw['statusPath'] ?? $path;
         $stmt->bindValue(':path', $path, SQLITE3_TEXT);
         $stmt->bindValue(':name', $sw['name'] ?? '', SQLITE3_TEXT);
         $stmt->bindValue(':command_path', $commandPath, SQLITE3_TEXT);
         $stmt->bindValue(':status_path', $statusPath, SQLITE3_TEXT);
-        $stmt->bindValue(':command_on_path', $commandOnPath, SQLITE3_TEXT);
-        $stmt->bindValue(':command_off_path', $commandOffPath, SQLITE3_TEXT);
         $stmt->execute();
     }
 }

--- a/index.html
+++ b/index.html
@@ -439,14 +439,21 @@ function addSensorCards() {
   });
 }
 
-function createCommandStatusRow(commandTopic, stateTopic) {
+function createCommandStatusRow(commandTopics, stateTopic) {
   const statusRow = document.createElement('div');
   statusRow.className = 'mt-2 flex flex-wrap gap-3 text-xs text-slate-500 dark:text-slate-400';
-  const commandStatus = document.createElement('span');
-  commandStatus.textContent = 'Command: --';
-  commandStatus.dataset.commandStatus = commandTopic;
-  commandStatusEls[commandTopic] = commandStatus;
-  statusRow.appendChild(commandStatus);
+  if (commandTopics && commandTopics.length > 0) {
+    commandTopics.forEach(({ topic, label }) => {
+      if (!topic) return;
+      const commandStatus = document.createElement('span');
+      const commandLabel = label || 'Command';
+      commandStatus.textContent = `${commandLabel}: --`;
+      commandStatus.dataset.commandStatus = topic;
+      commandStatus.dataset.commandLabel = commandLabel;
+      commandStatusEls[topic] = commandStatus;
+      statusRow.appendChild(commandStatus);
+    });
+  }
   if (stateTopic) {
     const stateStatus = document.createElement('span');
     stateStatus.textContent = 'State: waiting';
@@ -473,11 +480,11 @@ function createActionCard({ label, description, commandTopic, stateTopic, icon }
   header.appendChild(textWrap);
   header.appendChild(button);
   card.appendChild(header);
-  card.appendChild(createCommandStatusRow(commandTopic, stateTopic));
+  card.appendChild(createCommandStatusRow([{ topic: commandTopic }], stateTopic));
   return { card, button };
 }
 
-function createToggleCard({ label, description, stateTopic, commandTopic }) {
+function createToggleCard({ label, description, stateTopic, commandTopic, commandOnTopic, commandOffTopic }) {
   const card = document.createElement('div');
   card.className = 'rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-3 text-slate-800 shadow-sm transition dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100';
   const header = document.createElement('div');
@@ -488,12 +495,27 @@ function createToggleCard({ label, description, stateTopic, commandTopic }) {
   button.type = 'button';
   button.className = 'toggleButton relative inline-flex h-7 w-12 items-center rounded-full bg-slate-300 transition-colors duration-300 ease-out dark:bg-slate-700';
   button.dataset.topic = stateTopic;
-  button.dataset.commandTopic = commandTopic;
+  if (commandTopic) {
+    button.dataset.commandTopic = commandTopic;
+  }
+  if (commandOnTopic) {
+    button.dataset.commandTopicOn = commandOnTopic;
+  }
+  if (commandOffTopic) {
+    button.dataset.commandTopicOff = commandOffTopic;
+  }
   button.innerHTML = '<span class="inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition"></span>';
   header.appendChild(textWrap);
   header.appendChild(button);
   card.appendChild(header);
-  card.appendChild(createCommandStatusRow(commandTopic, stateTopic));
+  const commandTopics = [];
+  if (commandOnTopic || commandOffTopic) {
+    commandTopics.push({ topic: commandOnTopic, label: 'Command on' });
+    commandTopics.push({ topic: commandOffTopic, label: 'Command off' });
+  } else if (commandTopic) {
+    commandTopics.push({ topic: commandTopic });
+  }
+  card.appendChild(createCommandStatusRow(commandTopics, stateTopic));
   return { card, button };
 }
 
@@ -589,18 +611,28 @@ function addAuxSwitchCards() {
     return;
   }
   switches.forEach(sw => {
-    const commandTopic = sw.commandPath || sw.path || sw.statusPath;
-    const stateTopic = sw.statusPath || sw.path || sw.commandPath;
-    if (!commandTopic && !stateTopic) return;
+    const commandOnTopic = sw.commandOnPath || sw.commandPath || sw.path || '';
+    const commandOffTopic = sw.commandOffPath || sw.commandPath || sw.path || '';
+    const stateTopic = sw.statusPath || sw.path || '';
+    const hasCommand = commandOnTopic || commandOffTopic;
+    if (!hasCommand && !stateTopic) return;
     const { card } = createToggleCard({
-      label: sw.name || stateTopic || commandTopic,
+      label: sw.name || stateTopic || commandOnTopic || commandOffTopic,
       description: 'Auxiliary MQTT integration.',
       stateTopic,
-      commandTopic
+      commandOnTopic,
+      commandOffTopic,
+      commandTopic: !sw.commandOnPath && !sw.commandOffPath ? sw.commandPath || sw.path || '' : ''
     });
     container.appendChild(card);
     if (stateTopic) {
       topics.add(stateTopic);
+    }
+    if (commandOnTopic) {
+      topics.add(commandOnTopic);
+    }
+    if (commandOffTopic) {
+      topics.add(commandOffTopic);
     }
   });
 }
@@ -812,9 +844,16 @@ try {
     button.addEventListener('click', function() {
       const stateTopic = this.getAttribute('data-topic');
       const commandTopic = this.getAttribute('data-command-topic');
+      const commandTopicOn = this.getAttribute('data-command-topic-on');
+      const commandTopicOff = this.getAttribute('data-command-topic-off');
       const currentState = stateValues[stateTopic] === '1' ? '1' : '0';
       const newState = currentState === '1' ? '0' : '1';
-      sendCommand(commandTopic, newState);
+      if (commandTopicOn || commandTopicOff) {
+        const targetTopic = newState === '1' ? commandTopicOn : commandTopicOff;
+        sendCommand(targetTopic, newState);
+      } else {
+        sendCommand(commandTopic, newState);
+      }
     });
   });
 
@@ -839,7 +878,8 @@ function formatTimestamp(date) {
 function updateCommandStatus(commandTopic, payload) {
   const el = commandStatusEls[commandTopic];
   if (!el) return;
-  el.textContent = `Command: ${payload} at ${formatTimestamp(new Date())}`;
+  const label = el.dataset.commandLabel || 'Command';
+  el.textContent = `${label}: ${payload} at ${formatTimestamp(new Date())}`;
 }
 
 function updateStateStatus(topic, value) {

--- a/index.html
+++ b/index.html
@@ -439,20 +439,15 @@ function addSensorCards() {
   });
 }
 
-function createCommandStatusRow(commandTopics, stateTopic) {
+function createCommandStatusRow(commandTopic, stateTopic) {
   const statusRow = document.createElement('div');
   statusRow.className = 'mt-2 flex flex-wrap gap-3 text-xs text-slate-500 dark:text-slate-400';
-  if (commandTopics && commandTopics.length > 0) {
-    commandTopics.forEach(({ topic, label }) => {
-      if (!topic) return;
-      const commandStatus = document.createElement('span');
-      const commandLabel = label || 'Command';
-      commandStatus.textContent = `${commandLabel}: --`;
-      commandStatus.dataset.commandStatus = topic;
-      commandStatus.dataset.commandLabel = commandLabel;
-      commandStatusEls[topic] = commandStatus;
-      statusRow.appendChild(commandStatus);
-    });
+  if (commandTopic) {
+    const commandStatus = document.createElement('span');
+    commandStatus.textContent = 'Command: --';
+    commandStatus.dataset.commandStatus = commandTopic;
+    commandStatusEls[commandTopic] = commandStatus;
+    statusRow.appendChild(commandStatus);
   }
   if (stateTopic) {
     const stateStatus = document.createElement('span');
@@ -480,11 +475,11 @@ function createActionCard({ label, description, commandTopic, stateTopic, icon }
   header.appendChild(textWrap);
   header.appendChild(button);
   card.appendChild(header);
-  card.appendChild(createCommandStatusRow([{ topic: commandTopic }], stateTopic));
+  card.appendChild(createCommandStatusRow(commandTopic, stateTopic));
   return { card, button };
 }
 
-function createToggleCard({ label, description, stateTopic, commandTopic, commandOnTopic, commandOffTopic }) {
+function createToggleCard({ label, description, stateTopic, commandTopic }) {
   const card = document.createElement('div');
   card.className = 'rounded-2xl border border-slate-200/60 bg-white/70 px-4 py-3 text-slate-800 shadow-sm transition dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100';
   const header = document.createElement('div');
@@ -495,27 +490,12 @@ function createToggleCard({ label, description, stateTopic, commandTopic, comman
   button.type = 'button';
   button.className = 'toggleButton relative inline-flex h-7 w-12 items-center rounded-full bg-slate-300 transition-colors duration-300 ease-out dark:bg-slate-700';
   button.dataset.topic = stateTopic;
-  if (commandTopic) {
-    button.dataset.commandTopic = commandTopic;
-  }
-  if (commandOnTopic) {
-    button.dataset.commandTopicOn = commandOnTopic;
-  }
-  if (commandOffTopic) {
-    button.dataset.commandTopicOff = commandOffTopic;
-  }
+  button.dataset.commandTopic = commandTopic;
   button.innerHTML = '<span class="inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition"></span>';
   header.appendChild(textWrap);
   header.appendChild(button);
   card.appendChild(header);
-  const commandTopics = [];
-  if (commandOnTopic || commandOffTopic) {
-    commandTopics.push({ topic: commandOnTopic, label: 'Command on' });
-    commandTopics.push({ topic: commandOffTopic, label: 'Command off' });
-  } else if (commandTopic) {
-    commandTopics.push({ topic: commandTopic });
-  }
-  card.appendChild(createCommandStatusRow(commandTopics, stateTopic));
+  card.appendChild(createCommandStatusRow(commandTopic, stateTopic));
   return { card, button };
 }
 
@@ -611,28 +591,18 @@ function addAuxSwitchCards() {
     return;
   }
   switches.forEach(sw => {
-    const commandOnTopic = sw.commandOnPath || sw.commandPath || sw.path || '';
-    const commandOffTopic = sw.commandOffPath || sw.commandPath || sw.path || '';
+    const commandTopic = sw.commandPath || sw.path || sw.statusPath;
     const stateTopic = sw.statusPath || sw.path || '';
-    const hasCommand = commandOnTopic || commandOffTopic;
-    if (!hasCommand && !stateTopic) return;
+    if (!commandTopic && !stateTopic) return;
     const { card } = createToggleCard({
-      label: sw.name || stateTopic || commandOnTopic || commandOffTopic,
+      label: sw.name || stateTopic || commandTopic,
       description: 'Auxiliary MQTT integration.',
       stateTopic,
-      commandOnTopic,
-      commandOffTopic,
-      commandTopic: !sw.commandOnPath && !sw.commandOffPath ? sw.commandPath || sw.path || '' : ''
+      commandTopic
     });
     container.appendChild(card);
     if (stateTopic) {
       topics.add(stateTopic);
-    }
-    if (commandOnTopic) {
-      topics.add(commandOnTopic);
-    }
-    if (commandOffTopic) {
-      topics.add(commandOffTopic);
     }
   });
 }
@@ -844,16 +814,9 @@ try {
     button.addEventListener('click', function() {
       const stateTopic = this.getAttribute('data-topic');
       const commandTopic = this.getAttribute('data-command-topic');
-      const commandTopicOn = this.getAttribute('data-command-topic-on');
-      const commandTopicOff = this.getAttribute('data-command-topic-off');
       const currentState = stateValues[stateTopic] === '1' ? '1' : '0';
       const newState = currentState === '1' ? '0' : '1';
-      if (commandTopicOn || commandTopicOff) {
-        const targetTopic = newState === '1' ? commandTopicOn : commandTopicOff;
-        sendCommand(targetTopic, newState);
-      } else {
-        sendCommand(commandTopic, newState);
-      }
+      sendCommand(commandTopic, newState);
     });
   });
 
@@ -878,8 +841,7 @@ function formatTimestamp(date) {
 function updateCommandStatus(commandTopic, payload) {
   const el = commandStatusEls[commandTopic];
   if (!el) return;
-  const label = el.dataset.commandLabel || 'Command';
-  el.textContent = `${label}: ${payload} at ${formatTimestamp(new Date())}`;
+  el.textContent = `Command: ${payload} at ${formatTimestamp(new Date())}`;
 }
 
 function updateStateStatus(topic, value) {

--- a/settings.html
+++ b/settings.html
@@ -178,7 +178,7 @@
               <section class="space-y-4">
                 <div class="flex flex-col gap-1">
                   <h2 class="text-xl font-semibold text-slate-900 dark:text-white">Switches</h2>
-                  <p class="text-sm text-slate-600 dark:text-slate-300/80">Create quick toggles for auxiliary equipment, with separate command and status topics.</p>
+                  <p class="text-sm text-slate-600 dark:text-slate-300/80">Create quick toggles for auxiliary equipment, with separate on/off command topics and a status topic.</p>
                 </div>
                 <div id="switchesList" class="space-y-3"></div>
                 <button type="button" id="addSwitch" class="inline-flex items-center gap-2 rounded-xl border border-aurora-300/50 bg-aurora-300/20 px-4 py-2 text-sm font-semibold text-aurora-600 transition hover:-translate-y-0.5 hover:bg-aurora-300/30 dark:border-aurora-500/40 dark:bg-aurora-500/10 dark:text-aurora-200"><i class="fa-solid fa-plus"></i> Add Switch</button>
@@ -305,7 +305,8 @@
       row.className = `${rowBase} switch-row`;
       row.innerHTML = `
         <input class="${inputBase} flex-1 min-w-[10rem] switch-name" placeholder="Name" value="${data.name || ''}">
-        <input class="${inputBase} flex-1 min-w-[12rem] switch-command" placeholder="Command Topic" value="${data.commandPath || data.path || ''}">
+        <input class="${inputBase} flex-1 min-w-[12rem] switch-command-on" placeholder="Command On Topic" value="${data.commandOnPath || data.commandPath || data.path || ''}">
+        <input class="${inputBase} flex-1 min-w-[12rem] switch-command-off" placeholder="Command Off Topic" value="${data.commandOffPath || data.commandPath || data.path || ''}">
         <input class="${inputBase} flex-1 min-w-[12rem] switch-status" placeholder="Status Topic" value="${data.statusPath || data.path || ''}">
         <button type="button" class="remove inline-flex h-10 w-10 items-center justify-center rounded-xl bg-rose-500/80 text-white shadow transition hover:bg-rose-500"><i class="fa-solid fa-xmark"></i></button>`;
       row.querySelector('.remove').addEventListener('click', () => row.remove());
@@ -360,7 +361,8 @@
         })),
         switches: Array.from(document.querySelectorAll('.switch-row')).map(r => ({
           name: r.querySelector('.switch-name').value,
-          commandPath: r.querySelector('.switch-command').value,
+          commandOnPath: r.querySelector('.switch-command-on').value,
+          commandOffPath: r.querySelector('.switch-command-off').value,
           statusPath: r.querySelector('.switch-status').value
         })),
         roof: {

--- a/settings.html
+++ b/settings.html
@@ -178,7 +178,7 @@
               <section class="space-y-4">
                 <div class="flex flex-col gap-1">
                   <h2 class="text-xl font-semibold text-slate-900 dark:text-white">Switches</h2>
-                  <p class="text-sm text-slate-600 dark:text-slate-300/80">Create quick toggles for auxiliary equipment, with separate on/off command topics and a status topic.</p>
+                  <p class="text-sm text-slate-600 dark:text-slate-300/80">Create quick toggles for auxiliary equipment, with a command topic and a status topic.</p>
                 </div>
                 <div id="switchesList" class="space-y-3"></div>
                 <button type="button" id="addSwitch" class="inline-flex items-center gap-2 rounded-xl border border-aurora-300/50 bg-aurora-300/20 px-4 py-2 text-sm font-semibold text-aurora-600 transition hover:-translate-y-0.5 hover:bg-aurora-300/30 dark:border-aurora-500/40 dark:bg-aurora-500/10 dark:text-aurora-200"><i class="fa-solid fa-plus"></i> Add Switch</button>
@@ -305,8 +305,7 @@
       row.className = `${rowBase} switch-row`;
       row.innerHTML = `
         <input class="${inputBase} flex-1 min-w-[10rem] switch-name" placeholder="Name" value="${data.name || ''}">
-        <input class="${inputBase} flex-1 min-w-[12rem] switch-command-on" placeholder="Command On Topic" value="${data.commandOnPath || data.commandPath || data.path || ''}">
-        <input class="${inputBase} flex-1 min-w-[12rem] switch-command-off" placeholder="Command Off Topic" value="${data.commandOffPath || data.commandPath || data.path || ''}">
+        <input class="${inputBase} flex-1 min-w-[12rem] switch-command" placeholder="Command Topic" value="${data.commandPath || data.path || ''}">
         <input class="${inputBase} flex-1 min-w-[12rem] switch-status" placeholder="Status Topic" value="${data.statusPath || data.path || ''}">
         <button type="button" class="remove inline-flex h-10 w-10 items-center justify-center rounded-xl bg-rose-500/80 text-white shadow transition hover:bg-rose-500"><i class="fa-solid fa-xmark"></i></button>`;
       row.querySelector('.remove').addEventListener('click', () => row.remove());
@@ -361,8 +360,7 @@
         })),
         switches: Array.from(document.querySelectorAll('.switch-row')).map(r => ({
           name: r.querySelector('.switch-name').value,
-          commandOnPath: r.querySelector('.switch-command-on').value,
-          commandOffPath: r.querySelector('.switch-command-off').value,
+          commandPath: r.querySelector('.switch-command').value,
           statusPath: r.querySelector('.switch-status').value
         })),
         roof: {


### PR DESCRIPTION
### Motivation
- Auxiliary switches should be able to publish separate ON and OFF commands while still exposing a status topic so UI elements reflect true device state. 
- Preserve existing single-topic behavior while allowing richer multi-topic integrations for devices that expect different topics for on/off commands. 

### Description
- Add support for separate on/off command topics in the dashboard UI by extending toggle card creation to accept `commandOnTopic` and `commandOffTopic` and choosing the appropriate topic when toggling. (updated `index.html`) 
- Show labelled command status entries for each command topic so the dashboard displays `Command on` / `Command off` timestamps and payloads. (updated `index.html`) 
- Extend `settings.html` to collect `Command On Topic`, `Command Off Topic` and `Status Topic` fields and submit them via the settings payload as `commandOnPath`, `commandOffPath`, and `statusPath`. (updated `settings.html`) 
- Extend persistence and migrations in `config.php` to add `command_on_path` and `command_off_path` columns, plus populate `commandOnPath`/`commandOffPath` in the returned switch objects while preserving fallbacks to legacy single-topic values. (updated `config.php`) 
- Document the new capability in `AGENTS.md`. (updated `AGENTS.md`) 

### Testing
- Performed a headless smoke test by serving the repository with `python -m http.server` and using a Playwright script to open `/settings.html` and capture a screenshot, which loaded successfully. 
- No database-dependent tests were run. 
- Basic static verification (grep/sed/commits) and commits were created successfully during the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e23dbe6d4832eb1ff3c57c16d4d0a)