### PR TITLE
Improve settings save button contrast and clarify InfluxDB host format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
 - Sensors may specify InfluxDB `influxMeasurement` and `influxField` values in settings to enable historical data charts. When present, the sensor card displays a history icon linking to `history.html`.
 - Global InfluxDB connection settings (host, organization, bucket) are editable in settings and returned via `get_config.php`.
 - InfluxDB queries must use `POST` requests to `/api/v2/query` with `Content-Type: application/vnd.flux` and `Accept: application/csv` headers.
+- InfluxDB host settings should be saved as a full base URL including scheme and port (for example, `http://influxdb:8086`).
 
 - When all sensors indicate green, the sensors card shows a green border.
 

--- a/settings.html
+++ b/settings.html
@@ -136,7 +136,8 @@
                 <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
                   <div class="flex flex-col gap-2">
                     <label class="text-sm font-medium text-slate-700 dark:text-slate-200">Host</label>
-                    <input name="INFLUX_HOST" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                    <input name="INFLUX_HOST" placeholder="http://localhost:8086" class="rounded-xl border border-slate-200/70 bg-white/80 px-3 py-2 text-sm font-medium text-slate-800 shadow-sm transition focus:border-aurora-400 focus:outline-none focus:ring-2 focus:ring-aurora-300/40 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100" />
+                    <p class="text-xs text-slate-500 dark:text-slate-400">Use the full base URL including scheme and port (e.g. http://influxdb:8086).</p>
                   </div>
                   <div class="flex flex-col gap-2">
                     <label class="text-sm font-medium text-slate-700 dark:text-slate-200">Org</label>
@@ -196,7 +197,7 @@
               </section>
 
               <div class="flex flex-col gap-3">
-                <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-aurora-400 via-blue-500 to-indigo-500 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-aurora-300/30 transition hover:shadow-xl hover:shadow-aurora-300/40">
+                <button type="submit" class="inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-aurora-300 via-blue-400 to-indigo-500 px-6 py-3 text-sm font-semibold text-slate-900 shadow-lg shadow-aurora-300/30 transition hover:shadow-xl hover:shadow-aurora-300/40 dark:from-aurora-400 dark:via-blue-500 dark:to-indigo-500 dark:text-white">
                   <i class="fa-solid fa-floppy-disk"></i> Save Configuration
                 </button>
                 <div id="status" class="text-sm text-rose-500"></div>


### PR DESCRIPTION
### Motivation
- Make the Save Configuration control readable in light mode and avoid low-contrast text on the save button.  
- Clarify how users should enter the InfluxDB host so client code and history requests use a predictable base URL.

### Description
- Add a placeholder and a small helper line to the `INFLUX_HOST` input in `settings.html` to show the expected full base URL including scheme and port (example: `http://influxdb:8086`).
- Adjust the save button gradient and text color classes in `settings.html` to ensure sufficient contrast in light mode and preserve dark-mode styling.
- Update `AGENTS.md` to document that the InfluxDB host setting should be saved as a full base URL including scheme and port.

### Testing
- Performed an automated headless browser check using Playwright which loaded `settings.html` with `theme = light` and produced a screenshot artifact (`settings-light.png`), and the run completed successfully.  
- No database-dependent tests were run.  
- There are no unit tests configured for this change in the repository.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f375d7354832eb3547885f596f62d)