### PR TITLE
Make history chart fill available space (responsive)

### DIFF
--- a/history.html
+++ b/history.html
@@ -96,7 +96,7 @@
         </button>
       </header>
       <main class="flex-1 px-4 py-10 sm:px-8">
-        <div class="mx-auto flex w-full max-w-6xl flex-col gap-8">
+        <div class="mx-auto flex w-full max-w-none flex-col gap-8">
           <div class="flex flex-col gap-3">
             <p class="text-sm uppercase tracking-[0.35em] text-slate-500/70 dark:text-slate-300/60">History</p>
             <h1 class="text-4xl font-semibold tracking-tight text-slate-900 dark:text-white"><span class="bg-gradient-to-r from-aurora-400 via-blue-500 to-purple-500 bg-clip-text text-transparent">Sensor History</span></h1>
@@ -111,7 +111,7 @@
                 <button data-range="week" class="range-btn inline-flex items-center gap-2 rounded-xl border border-slate-200/70 bg-white/70 px-4 py-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-600 transition hover:-translate-y-0.5 hover:border-aurora-300/40 hover:bg-aurora-300/20 hover:text-aurora-600 dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:border-aurora-500/40 dark:hover:bg-aurora-500/10 dark:hover:text-aurora-200"><i class="fa-solid fa-calendar-week"></i> This Week</button>
               </div>
             </div>
-            <div id="historyChart" class="mt-6 min-h-[18rem] rounded-2xl border border-slate-200/60 bg-slate-900/5 dark:border-white/10 dark:bg-black/20"></div>
+            <div id="historyChart" class="mt-6 h-[55vh] min-h-[18rem] sm:min-h-[22rem] lg:min-h-[30rem] rounded-2xl border border-slate-200/60 bg-slate-900/5 dark:border-white/10 dark:bg-black/20"></div>
             <details id="debugPanel" class="group mt-6 rounded-2xl border border-slate-200/60 bg-white/70 p-5 text-sm text-slate-700 shadow-inner backdrop-blur dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-200">
               <summary class="cursor-pointer list-none font-semibold text-slate-900 transition group-open:text-aurora-500 dark:text-white">
                 <i class="fa-solid fa-bug mr-2 text-aurora-500"></i>Debug details


### PR DESCRIPTION
### Motivation
- The history chart was rendered as a small block with a constrained container, so update the layout so the chart uses the available width and height and behaves well on mobile devices.

### Description
- Allow the page content to use full width by changing the wrapper from `max-w-6xl` to `max-w-none` and increase the chart container to `h-[55vh]` with responsive `min-h` values (`min-h-[18rem]`, `sm:min-h-[22rem]`, `lg:min-h-[30rem]`) in `history.html` so the Highcharts area fills the page more naturally.

### Testing
- Served the site with `python -m http.server 8000` and ran a Playwright script to load `history.html` and capture a screenshot which confirmed the chart area expanded and fills the available space (artifact produced successfully); no database-dependent tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f426f6560832e8edb485e0c3ae4da)