### PR TITLE
Add startup and shutdown MQTT scripts for observatory power control

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,4 @@
 - Auxiliary switches use a single command topic (1/0 payloads) alongside a status topic (1/0).
 - History page includes a Debug details panel that can be auto-opened with `?debug=1` to surface InfluxDB configuration and query diagnostics.
 - History charts overlay the previous period as a dotted comparison series aligned to the current range.
+- Added `scripts/roof/startup.sh` and `scripts/roof/shutdown.sh` to publish MQTT relay commands for 12V power, dew heater power, and mount/focus power, configurable via environment variables.

--- a/scripts/roof/shutdown.sh
+++ b/scripts/roof/shutdown.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Power down observatory equipment after an observing session.
+set -euo pipefail
+# Ensure a predictable PATH for system utilities like mosquitto_pub.
+export PATH="/usr/bin:/bin"
+
+MOSQUITTO_PUB_BIN="${MOSQUITTO_PUB_BIN:-mosquitto_pub}"
+MQTT_HOST="${MQTT_HOST:-localhost}"
+MQTT_PORT="${MQTT_PORT:-1883}"
+MQTT_USERNAME="${MQTT_USERNAME:-}"
+MQTT_PASSWORD="${MQTT_PASSWORD:-}"
+MQTT_BASE_TOPIC="${MQTT_BASE_TOPIC:-Observatory/roof-esp/command}"
+MQTT_QOS="${MQTT_QOS:-1}"
+MQTT_OFF_PAYLOAD="${MQTT_OFF_PAYLOAD:-0}"
+
+if ! command -v "${MOSQUITTO_PUB_BIN}" >/dev/null 2>&1; then
+  echo "mosquitto_pub not found; set MOSQUITTO_PUB_BIN or install mosquitto clients." >&2
+  exit 1
+fi
+
+publish_command() {
+  local topic="$1"
+  local payload="$2"
+  local args=("-h" "$MQTT_HOST" "-p" "$MQTT_PORT" "-q" "$MQTT_QOS" "-t" "$topic" "-m" "$payload")
+  if [[ -n "$MQTT_USERNAME" ]]; then
+    args+=("-u" "$MQTT_USERNAME")
+  fi
+  if [[ -n "$MQTT_PASSWORD" ]]; then
+    args+=("-P" "$MQTT_PASSWORD")
+  fi
+  "$MOSQUITTO_PUB_BIN" "${args[@]}"
+}
+
+publish_command "${MQTT_BASE_TOPIC}/relay3" "$MQTT_OFF_PAYLOAD"
+publish_command "${MQTT_BASE_TOPIC}/relay7" "$MQTT_OFF_PAYLOAD"
+publish_command "${MQTT_BASE_TOPIC}/relay8" "$MQTT_OFF_PAYLOAD"

--- a/scripts/roof/startup.sh
+++ b/scripts/roof/startup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Power up observatory equipment for an observing session.
+set -euo pipefail
+# Ensure a predictable PATH for system utilities like mosquitto_pub.
+export PATH="/usr/bin:/bin"
+
+MOSQUITTO_PUB_BIN="${MOSQUITTO_PUB_BIN:-mosquitto_pub}"
+MQTT_HOST="${MQTT_HOST:-localhost}"
+MQTT_PORT="${MQTT_PORT:-1883}"
+MQTT_USERNAME="${MQTT_USERNAME:-}"
+MQTT_PASSWORD="${MQTT_PASSWORD:-}"
+MQTT_BASE_TOPIC="${MQTT_BASE_TOPIC:-Observatory/roof-esp/command}"
+MQTT_QOS="${MQTT_QOS:-1}"
+MQTT_ON_PAYLOAD="${MQTT_ON_PAYLOAD:-1}"
+
+if ! command -v "${MOSQUITTO_PUB_BIN}" >/dev/null 2>&1; then
+  echo "mosquitto_pub not found; set MOSQUITTO_PUB_BIN or install mosquitto clients." >&2
+  exit 1
+fi
+
+publish_command() {
+  local topic="$1"
+  local payload="$2"
+  local args=("-h" "$MQTT_HOST" "-p" "$MQTT_PORT" "-q" "$MQTT_QOS" "-t" "$topic" "-m" "$payload")
+  if [[ -n "$MQTT_USERNAME" ]]; then
+    args+=("-u" "$MQTT_USERNAME")
+  fi
+  if [[ -n "$MQTT_PASSWORD" ]]; then
+    args+=("-P" "$MQTT_PASSWORD")
+  fi
+  "$MOSQUITTO_PUB_BIN" "${args[@]}"
+}
+
+publish_command "${MQTT_BASE_TOPIC}/relay3" "$MQTT_ON_PAYLOAD"
+publish_command "${MQTT_BASE_TOPIC}/relay7" "$MQTT_ON_PAYLOAD"
+publish_command "${MQTT_BASE_TOPIC}/relay8" "$MQTT_ON_PAYLOAD"


### PR DESCRIPTION
### Motivation
- Provide simple CLI scripts to power up and power down observatory equipment at session start/end by publishing the appropriate MQTT commands to the roof controller relays.

### Description
- Add `scripts/roof/startup.sh` which publishes the ON payload to `${MQTT_BASE_TOPIC}/relay3`, `/relay7`, and `/relay8` and supports configuration via environment variables like `MOSQUITTO_PUB_BIN`, `MQTT_HOST`, `MQTT_PORT`, `MQTT_USERNAME`, `MQTT_PASSWORD`, `MQTT_QOS`, and `MQTT_ON_PAYLOAD`.
- Add `scripts/roof/shutdown.sh` which publishes the OFF payload to the same three relay topics and supports `MQTT_OFF_PAYLOAD` and the same connection/config environment variables.
- Both scripts validate presence of `mosquitto_pub`, use a predictable `PATH`, use `set -euo pipefail`, and are marked executable.
- Document the new scripts in `AGENTS.md`.

### Testing
- No automated tests are configured for these changes, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f44ed35fc832ebb1c43418b41858b)