### PR TITLE
Round history chart labels and tooltips to one decimal

### DIFF
--- a/history.html
+++ b/history.html
@@ -234,7 +234,12 @@
           tickColor: isDark ? '#334155' : '#94a3b8'
         },
         yAxis: {
-          labels: { style: { color: isDark ? '#e2e8f0' : '#0f172a' } },
+          labels: {
+            style: { color: isDark ? '#e2e8f0' : '#0f172a' },
+            formatter() {
+              return Highcharts.numberFormat(this.value, 1);
+            }
+          },
           title: { style: { color: isDark ? '#e2e8f0' : '#0f172a' } },
           gridLineColor: isDark ? '#1f2937' : '#e2e8f0',
           lineColor: isDark ? '#334155' : '#cbd5f5',
@@ -244,7 +249,8 @@
         tooltip: {
           backgroundColor: isDark ? '#111827' : '#ffffff',
           borderColor: isDark ? '#1d4ed8' : '#dbeafe',
-          style: { color: isDark ? '#f3f4f6' : '#0f172a' }
+          style: { color: isDark ? '#f3f4f6' : '#0f172a' },
+          valueDecimals: 1
         }
       });
     }


### PR DESCRIPTION
### Motivation
- History charts display values with many decimal places which reduces readability, so labels and tooltip values should be rounded to one decimal place.

### Description
- Tweak `history.html` `applyChartTheme` options to format y-axis labels with `Highcharts.numberFormat(this.value, 1)` and enforce `tooltip.valueDecimals = 1` so chart axes and tooltips show one decimal.

### Testing
- Started a local PHP dev server with `php -S 0.0.0.0:8000 -t /workspace/pi-roof` and ran a headless Playwright script to load `history.html?sensor=demo` and capture a screenshot, and the page loaded and the screenshot was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837e2dbe98832eb802e3a4181e6c87)